### PR TITLE
Fix CO_OBJ_TYPE const qualifier

### DIFF
--- a/canopen/include/co_obj.h
+++ b/canopen/include/co_obj.h
@@ -479,19 +479,19 @@ struct CO_DICT_T;              /* Declaration of object dictionary structure */
 *    entry.
 */
 typedef struct CO_OBJ_T {
-    uint32_t              Key;   /*!< 16Bit Index, 8Bit Subindex, 8Bit Flags */
-                                 /*   - 0: 1=rd access allowed               */
-                                 /*   - 1: 1=wr access allowed               */
-                                 /*   - 2: 1=pdo mappable                    */
-                                 /*   - 3: 1=signed value                    */
-                                 /*   - 4: |- valid bytes in 2^n; used if    */
-                                 /*   - 5: |  Type=0, or Type->Size ptr=0    */
-                                 /*   - 6: 1=+/- node-id on read/write       */
-                                 /*   - 7: 1=direct (ptr is value if Type=0) */
-    struct CO_OBJ_TYPE_T *Type;  /*!< ==0: value access via Data-Ptr,        */
-                                 /*   !=0: access via type structure         */
-    uintptr_t             Data;  /*!< Address of value or data structure     */
-                                 /*   or data value for direct access        */
+    uint32_t                    Key;   /*!< 16Bit Index, 8Bit Subindex, 8Bit Flags */
+                                       /*   - 0: 1=rd access allowed               */
+                                       /*   - 1: 1=wr access allowed               */
+                                       /*   - 2: 1=pdo mappable                    */
+                                       /*   - 3: 1=signed value                    */
+                                       /*   - 4: |- valid bytes in 2^n; used if    */
+                                       /*   - 5: |  Type=0, or Type->Size ptr=0    */
+                                       /*   - 6: 1=+/- node-id on read/write       */
+                                       /*   - 7: 1=direct (ptr is value if Type=0) */
+    const struct CO_OBJ_TYPE_T *Type;  /*!< ==0: value access via Data-Ptr,        */
+                                       /*   !=0: access via type structure         */
+    uintptr_t                   Data;  /*!< Address of value or data structure     */
+                                       /*   or data value for direct access        */
 } CO_OBJ;
 
 /*!< Size type function prototype */

--- a/canopen/source/co_obj.c
+++ b/canopen/source/co_obj.c
@@ -36,8 +36,8 @@ const CO_OBJ_TYPE COTDomain = { COTypeDomainSize, COTypeDomainCtrl, COTypeDomain
 */
 uint32_t COObjGetSize(struct CO_OBJ_T *obj, CO_NODE *node, uint32_t width)
 {
-    uint32_t     result = 0;
-    CO_OBJ_TYPE *type;
+    uint32_t           result = 0;
+    const CO_OBJ_TYPE *type;
 
     if (obj == 0) {
         return (result);
@@ -61,9 +61,9 @@ uint32_t COObjGetSize(struct CO_OBJ_T *obj, CO_NODE *node, uint32_t width)
 */
 CO_ERR COObjRdValue(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *value, uint8_t width, uint8_t nodeid)
 {
-    CO_ERR       result = CO_ERR_NONE;
-    CO_OBJ_TYPE *type;
-    uint32_t     val = 0;
+    CO_ERR             result = CO_ERR_NONE;
+    const CO_OBJ_TYPE *type;
+    uint32_t           val = 0;
 
     if ((obj == 0) || (value == 0)) {
         return (CO_ERR_BAD_ARG);
@@ -145,8 +145,8 @@ CO_ERR COObjWrValue(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *value, u
 */
 CO_ERR COObjRdBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buffer, uint32_t len)
 {
-    CO_OBJ_TYPE *type;
-    CO_ERR       result = CO_ERR_OBJ_ACC;
+    const CO_OBJ_TYPE *type;
+    CO_ERR             result = CO_ERR_OBJ_ACC;
 
     if ((obj == 0) || (buffer == 0)) {
         return (CO_ERR_BAD_ARG);
@@ -165,8 +165,8 @@ CO_ERR COObjRdBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *bu
 */
 CO_ERR COObjRdBufCont(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buffer, uint32_t len)
 {
-    CO_OBJ_TYPE *type;
-    CO_ERR       result = CO_ERR_OBJ_ACC;
+    const CO_OBJ_TYPE *type;
+    CO_ERR             result = CO_ERR_OBJ_ACC;
 
     if ((obj == 0) || (buffer == 0)) {
         return (CO_ERR_BAD_ARG);
@@ -186,8 +186,8 @@ CO_ERR COObjRdBufCont(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buf
 */
 CO_ERR COObjWrBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buffer, uint32_t len)
 {
-    CO_OBJ_TYPE *type;
-    CO_ERR       result = CO_ERR_OBJ_ACC;
+    const CO_OBJ_TYPE *type;
+    CO_ERR             result = CO_ERR_OBJ_ACC;
 
     if ((obj == 0) || (buffer == 0)) {
         return (CO_ERR_BAD_ARG);
@@ -206,8 +206,8 @@ CO_ERR COObjWrBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *bu
 */
 CO_ERR COObjWrBufCont(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buffer, uint32_t len)
 {
-    CO_OBJ_TYPE *type;
-    CO_ERR       result = CO_ERR_OBJ_ACC;
+    const CO_OBJ_TYPE *type;
+    CO_ERR             result = CO_ERR_OBJ_ACC;
 
     if ((obj == 0) || (buffer == 0)) {
         return (CO_ERR_BAD_ARG);
@@ -328,8 +328,8 @@ int16_t COObjCmp(struct CO_OBJ_T *obj, void *val)
 */
 CO_ERR COObjRdType(CO_OBJ *obj, struct CO_NODE_T *node, void *dst, uint32_t len, uint32_t off)
 {
-    CO_ERR       result = CO_ERR_OBJ_ACC;
-    CO_OBJ_TYPE *type;
+    CO_ERR             result = CO_ERR_OBJ_ACC;
+    const CO_OBJ_TYPE *type;
 
     type = obj->Type;
     if (type != 0) {
@@ -416,8 +416,8 @@ CO_ERR COObjWrDirect(CO_OBJ *obj, void *val, uint32_t len)
 */
 CO_ERR COObjWrType(CO_OBJ *obj, CO_NODE *node, void *src, uint32_t len, uint32_t off)
 {
-    CO_ERR       result = CO_ERR_OBJ_ACC;
-    CO_OBJ_TYPE *type;
+    CO_ERR             result = CO_ERR_OBJ_ACC;
+    const CO_OBJ_TYPE *type;
 
     type = obj->Type;
     if (type != 0) {


### PR DESCRIPTION
Commit 25fe52521593c2a697170da4532a07c627b400c0 introduced changes that cause const-ness errors related to the `CO_OBJ_TYPE` system. These changes broke my build configuration on arm-none-eabi-gcc 9-2020-q2-update. This pull request fixes this issue by adding `const` qualifiers in `co_obj.c` and `co_obj.h`.

The CO type preprocessor macros are defined as `const CO_OBJ_TYPE *`, e.g.:
```C
#define CO_TASYNC   ((const CO_OBJ_TYPE *)&COTAsync)   /*!< Asynchronous TPDO    */
```

This definition conflicts with the definition of the `CO_OBJ` struct:
```C
typedef struct CO_OBJ_T {
    uint32_t              Key;   /*!< 16Bit Index, 8Bit Subindex, 8Bit Flags */
                                 /*   - 0: 1=rd access allowed               */
                                 /*   - 1: 1=wr access allowed               */
                                 /*   - 2: 1=pdo mappable                    */
                                 /*   - 3: 1=signed value                    */
                                 /*   - 4: |- valid bytes in 2^n; used if    */
                                 /*   - 5: |  Type=0, or Type->Size ptr=0    */
                                 /*   - 6: 1=+/- node-id on read/write       */
                                 /*   - 7: 1=direct (ptr is value if Type=0) */
    struct CO_OBJ_TYPE_T *Type;  /*!< ==0: value access via Data-Ptr,        */
                                 /*   !=0: access via type structure         */
    uintptr_t             Data;  /*!< Address of value or data structure     */
                                 /*   or data value for direct access        */
} CO_OBJ;
```

As a result, it is no longer possible to define an object dictionary entry as follows:
```C
const CO_OBJ DemoObjDir[] = {
         :
    { CO_KEY(0x1800, 1, CO_UNSIGNED32 | CO_OBJ__N_RW), CO_TPDOID,   (uintptr_t)&MyCobId },
         :
};
```

In this case, you are trying to assign a pointer to a `const CO_OBJ_T` to a `CO_OBJ_T` pointer, which is forbidden:
```
../dependencies/canopen-stack/canopen/include/co_pdo.h:62:43: error: invalid conversion from 'const CO_OBJ_TYPE*' {aka 'const CO_OBJ_TYPE_T*'} to 'CO_OBJ_TYPE_T*' [-fpermissive]
   62 | #define CO_TPDOID   ((const CO_OBJ_TYPE *)&COTPdoId)   /*!< Dynamic Identifier   */
      |                                           ^~~~~~~~~
      |                                           |
      |                                           const CO_OBJ_TYPE* {aka const CO_OBJ_TYPE_T*}
../src/object_dictionary.cpp:72:56: note: in expansion of macro 'CO_TPDOID'
   72 |     { CO_KEY(0x1800, 1, CO_UNSIGNED32 | CO_OBJ__N_RW), CO_TPDOID,   make_dict_ptr(tpdo1_config.cob_id) },
      |                                                        ^~~~~~~~~
```

To me, it makes sense to change `CO_OBJ_T` so that the member `Type` is of type `const struct CO_OBJ_TYPE_T *` because:

1. In the most common use case, the `CO_OBJ_TYPE_T` structs will be constant (and can be stored in flash).
2. The CANopen stack does not need to write to the fields of the `Type` member.
3. Allowing the fields of a `CO_OBJ_TYPE_T` to change at runtime could potentially open up all sorts of edge case bugs.
4. Specialized dynamic behavior of object dictionary variables can be achieved through the 4 access functions instead.
