### PR TITLE
Broken RDPO connection

### DIFF
--- a/canopen/include/co_pdo.h
+++ b/canopen/include/co_pdo.h
@@ -38,7 +38,6 @@ extern "C" {
 #define CO_TPDO_COBID_EXT    ((uint32_t)1 << 29)    /*!< extended format     */
     
 #define CO_RPDO_COBID_OFF    ((uint32_t)1 << 31)    /*!< marked as unused    */
-#define CO_RPDO_COBID_REMOTE ((uint32_t)1 << 30)    /*!< RTR is not allowed  */
 #define CO_RPDO_COBID_EXT    ((uint32_t)1 << 29)    /*!< extended format     */
 
 #define CO_TPDO_FLG___E     0x01   /*!< PDO event occured                    */

--- a/canopen/source/co_pdo.c
+++ b/canopen/source/co_pdo.c
@@ -579,10 +579,6 @@ CO_ERR CORPdoReset(CO_RPDO *pdo, uint16_t num)
         pdo->Node->Error = CO_ERR_RPDO_COM_OBJ;
         return (CO_ERR_RPDO_COM_OBJ);
     }
-    if ((id & CO_RPDO_COBID_REMOTE) == 0) {
-        pdo->Node->Error = CO_ERR_RPDO_COM_OBJ;
-        return (CO_ERR_RPDO_COM_OBJ);
-    }
     if ((id & CO_RPDO_COBID_EXT) != 0) {
         pdo->Node->Error = CO_ERR_RPDO_COM_OBJ;
         return (CO_ERR_RPDO_COM_OBJ);


### PR DESCRIPTION
As RTR flag is not used in RDPO parameters, it is not relevant to keep the comparison of this flag in initialization process. (Was always true).

Cf Issue#33