### PR TITLE
NMT Reset causing fatal error if no EMCY table

### DIFF
--- a/canopen/source/co_nmt.c
+++ b/canopen/source/co_nmt.c
@@ -109,7 +109,9 @@ void CONmtReset(CO_NMT *nmt, CO_NMT_RESET type)
         CONmtInit(nmt, nmt->Node);
         COSdoInit(nmt->Node->Sdo, nmt->Node);
         COIfCanReset(&nmt->Node->If);
-        COEmcyReset(&nmt->Node->Emcy, 1);
+        if(nmt->Node->Emcy.Root != 0) {
+            COEmcyReset(&nmt->Node->Emcy, 1);
+        }
         COSyncInit(&nmt->Node->Sync, nmt->Node);
         if (nobootup == 0) {
             CONmtBootup(nmt);


### PR DESCRIPTION
Steps to reproduce :
-> No EMCY table in specs (NULL)
-> NMT master sends reset

--> Fatal error on node.

Reason : Even if we don't have EMCY table, CONmtReset function will call COEmcyReset which will point on a NULL pointer.