### PR TITLE
Introduce user defined SDO abort codes in type functions (fix #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and starting with version 4.1.0 this project adheres to [Semantic Versioning](ht
 
 ## [unreleased]
 
-- none
+none
+
+## [4.1.7] - 2012-07-28
+
+### Added
+
+- Introduce COObjTypeUserSDOAbort() to define amnufacturer specific SDO Abort codes within type functions
+- Add CMake toolchain files for ARM-GCC Cortex-M3, M4 and M7
 
 ## [4.1.6] - 2012-07-21
 
@@ -131,7 +138,8 @@ and starting with version 4.1.0 this project adheres to [Semantic Versioning](ht
 - First Open Source Release.
 
 
-[unreleased]: https://github.com/embedded-office/canopen-stack/compare/v4.1.6...HEAD
+[unreleased]: https://github.com/embedded-office/canopen-stack/compare/v4.1.7...HEAD
+[4.1.7]: https://github.com/embedded-office/canopen-stack/compare/v4.1.6...v4.1.7
 [4.1.6]: https://github.com/embedded-office/canopen-stack/compare/v4.1.5...v4.1.6
 [4.1.5]: https://github.com/embedded-office/canopen-stack/compare/v4.1.4...v4.1.5
 [4.1.4]: https://github.com/embedded-office/canopen-stack/compare/v4.1.3...v4.1.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.15)
-project (CanopenStack VERSION 4.1.6)
+project (CanopenStack VERSION 4.1.7)
 
 # Make CANopen library
 add_subdirectory(canopen)

--- a/canopen/CMakeLists.txt
+++ b/canopen/CMakeLists.txt
@@ -36,17 +36,3 @@ target_sources(Canopen
     source/co_tmr.c
     source/co_ver.c
 )
-
-#---
-# enable warnings and tread as errors
-#
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  # enable all warnings
-  target_compile_options(Canopen PRIVATE -Wall
-                                         -Wextra
-                                         -Wpedantic
-                                         -Werror)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(Canopen PRIVATE /W4
-                                         /WX)
-endif()

--- a/canopen/CMakeLists.txt
+++ b/canopen/CMakeLists.txt
@@ -26,7 +26,7 @@ target_sources(Canopen
     source/co_if_nvm.c
     source/co_if_timer.c
     source/co_if.c
-    source/co_lss.c 
+    source/co_lss.c
     source/co_nmt.c
     source/co_obj.c
     source/co_para.c
@@ -40,11 +40,7 @@ target_sources(Canopen
 #---
 # enable warnings and tread as errors
 #
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # tread all files as C files 
-    target_compile_options(Canopen PRIVATE /TC)
-  endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # enable all warnings
   target_compile_options(Canopen PRIVATE -Wall
                                          -Wextra

--- a/canopen/include/co_obj.h
+++ b/canopen/include/co_obj.h
@@ -852,6 +852,25 @@ CO_ERR COObjRdType(CO_OBJ *obj, struct CO_NODE_T *node, void *dst, uint32_t len,
 */
 CO_ERR COObjWrType(CO_OBJ *obj, struct CO_NODE_T *node, void *src, uint32_t len, uint32_t off);
 
+/*! \brief TYPE SPECIFIC SDO ABORT CODE
+*
+*    This function is responsible to set a user defined SDO abort code
+*    for the current transfer of an SDO server. This function is useful,
+*    when detecting an error within a type read od write function during
+*    an SDO transfer. If no SDO transfer is active, this function will
+*    do nothing.
+*
+* \param obj
+*    String object entry reference
+*
+* \param node
+*    reference to parent node
+*
+* \param abort
+*    Requested abort code (or 0 for standardized abort code)
+*/
+void COObjTypeUserSDOAbort(CO_OBJ *obj, struct CO_NODE_T *node, uint32_t abort);
+
 /*! \brief STRING OBJECT SIZE
 *
 *    This function is responsible to calculate and return the size of the

--- a/canopen/include/co_sdo_srv.h
+++ b/canopen/include/co_sdo_srv.h
@@ -144,6 +144,7 @@ typedef struct CO_SDO_T {
     CO_IF_FRM          *Frm;     /*!< SDO request/response CAN frame         */
     uint32_t            RxId;    /*!< SDO request CAN identifier             */
     uint32_t            TxId;    /*!< SDO response CAN identifier            */
+    uint32_t            Abort;   /*!< SDO abort code overwrite, when >0      */
     uint16_t            Idx;     /*!< Extracted Multiplexer Index            */
     uint8_t             Sub;     /*!< Extracted Multiplexer Subindex         */
     struct CO_SDO_BUF_T Buf;     /*!< Transfer buffer management structure   */

--- a/canopen/include/co_ver.h
+++ b/canopen/include/co_ver.h
@@ -29,7 +29,7 @@
 
 #define CO_VER_MAJOR          4
 #define CO_VER_MINOR          1
-#define CO_VER_BUILD          6
+#define CO_VER_BUILD          7
 
 /******************************************************************************
 * PUBLIC FUNCTIONS

--- a/canopen/source/co_obj.c
+++ b/canopen/source/co_obj.c
@@ -440,6 +440,21 @@ CO_ERR COObjWrType(CO_OBJ *obj, CO_NODE *node, void *src, uint32_t len, uint32_t
 /*
 * see function definition
 */
+void COObjTypeUserSDOAbort(CO_OBJ *obj, struct CO_NODE_T *node, uint32_t abort)
+{
+    uint8_t n;
+
+    for (n = 0; n < CO_SDOS_N; n++) {
+        if (node->Sdo[n].Obj == obj) {
+            node->Sdo[n].Abort = abort;
+            break;
+        }
+    }
+}
+
+/*
+* see function definition
+*/
 uint32_t COTypeStringSize(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint32_t width)
 {
     uint32_t    strlen = 0;

--- a/docs/docs/api/object/index.md
+++ b/docs/docs/api/object/index.md
@@ -29,6 +29,7 @@ The object component provides an interface to the individual object entries.
         +COObjWrBufCont(source, length) int16_t
         +COObjWrBufStart(source, length) int16_t
         +COObjWrValue(source, width, nodeId) int16_t
+        +COObjTypeUserSDOAbort(node, code) void
       }
 ```
 

--- a/docs/docs/usecase/dictionary.md
+++ b/docs/docs/usecase/dictionary.md
@@ -200,16 +200,16 @@ If a new user type didn't need to have special behavior on accessing (e.g. get-s
 The following list shows the type function prototypes. The return value of the size type function (e.g. `DemoSize()`) shall return the size of the user type in bytes. The other type functions shall return `CO_ERR_NONE` after the successful operation. If an error is detected the corresponding error codes must be returned: `CO_ERR_TYPE_RD`, `CO_ERR_TYPE_WR` or `CO_ERR_TYPE_CTRL`.
 
 ```c
-  uint32_t DemoSize (CO_OBJ *obj, uint32_t width);
-  CO_ERR   DemoRead (CO_OBJ *obj, void *buf, uint32_t len);
-  CO_ERR   DemoWrite(CO_OBJ *obj, void *buf, uint32_t len);
-  CO_ERR   DemoCtrl (CO_OBJ *obj, uint16_t id, uint32_t para);
+  uint32_t DemoSize (CO_OBJ *obj, CO_NODE *node, uint32_t width);
+  CO_ERR   DemoRead (CO_OBJ *obj, CO_NODE *node, void *buf, uint32_t len);
+  CO_ERR   DemoWrite(CO_OBJ *obj, CO_NODE *node, void *buf, uint32_t len);
+  CO_ERR   DemoCtrl (CO_OBJ *obj, CO_NODE *node, uint16_t id, uint32_t para);
 ```
 
 **Note:** The parameter `len` in the functions `DemoRead()` and `DemoWrite()` is the length of the data, given via the pointer `buf`. If you want to use the width of the object entry, you can use the following snippet:
 
 ```c
-CO_ERR DemoRead(CO_OBJ *obj, void *buf, uint32_t len)
+CO_ERR DemoRead(CO_OBJ *obj, CO_NODE *node, void *buf, uint32_t len)
 {
     uint32_t width = CO_GET_SIZE(obj->Key);
 
@@ -253,4 +253,19 @@ sequenceDiagram
     T-->>-O: value
     O-->>-D: value
     D-->>-A: value
+```
+
+When you need to control the ABORT codes of SDO expedited transfers, you can use the function `COObjTypeUserSDOAbort()` to set a user defined SDO abort code within your type functions:
+
+```c
+CO_ERR DemoWrite(CO_OBJ *obj, CO_NODE *node, void *buf, uint32_t len)
+{
+    :
+  if (/* your write error condition */) {
+      /* the given abort code is considered in SDO transfers only! */
+      COObjTypeUserSDOAbort(obj, node, 0x12345678);
+      return CO_ERR_TYPE_WR;
+  }
+    :
+}
 ```

--- a/driver/source/co_can_dummy.c
+++ b/driver/source/co_can_dummy.c
@@ -18,7 +18,7 @@
 * INCLUDES
 ******************************************************************************/
 
-/* TODO: rename the include file name to match the naming convention: 
+/* TODO: rename the include file name to match the naming convention:
  *   co_can_<device>.h
  */
 #include "co_can_dummy.h"
@@ -44,7 +44,7 @@ static void    DrvCanClose  (void);
 * PUBLIC VARIABLE
 ******************************************************************************/
 
-/* TODO: rename the variable to match the naming convention: 
+/* TODO: rename the variable to match the naming convention:
  *   <device>CanDriver
  */
 const CO_IF_CAN_DRV DummyCanDriver = {
@@ -67,17 +67,23 @@ static void DrvCanInit(void)
 
 static void DrvCanEnable(uint32_t baudrate)
 {
+    (void)baudrate;
+
     /* TODO: set the given baudrate to the CAN controller */
 }
 
 static int16_t DrvCanSend(CO_IF_FRM *frm)
 {
+    (void)frm;
+
     /* TODO: wait for free CAN message slot and send the given CAN frame */
     return (0u);
 }
 
 static int16_t DrvCanRead (CO_IF_FRM *frm)
 {
+    (void)frm;
+
     /* TODO: wait for a CAN frame and read CAN frame from the CAN controller */
     return (0u);
 }

--- a/driver/source/co_nvm_dummy.c
+++ b/driver/source/co_nvm_dummy.c
@@ -18,7 +18,7 @@
 * INCLUDES
 ******************************************************************************/
 
-/* TODO: rename the include file name to match the naming convention: 
+/* TODO: rename the include file name to match the naming convention:
  *   co_nvm_<device>.h
  */
 #include "co_nvm_dummy.h"
@@ -42,7 +42,7 @@ static uint32_t DrvNvmWrite (uint32_t start, uint8_t *buffer, uint32_t size);
 * PUBLIC VARIABLE
 ******************************************************************************/
 
-/* TODO: rename the variable to match the naming convention: 
+/* TODO: rename the variable to match the naming convention:
  *   <device>NvmDriver
  */
 const CO_IF_NVM_DRV DummyNvmDriver = {
@@ -62,12 +62,20 @@ static void DrvNvmInit(void)
 
 static uint32_t DrvNvmRead(uint32_t start, uint8_t *buffer, uint32_t size)
 {
+    (void)start;
+    (void)buffer;
+    (void)size;
+
     /* TODO: read a memory block from non-volatile memory into given buffer */
     return (0u);
 }
 
 static uint32_t DrvNvmWrite(uint32_t start, uint8_t *buffer, uint32_t size)
 {
+    (void)start;
+    (void)buffer;
+    (void)size;
+
     /* TODO: write content of given buffer into non-volatile memory */
     return (0u);
 }

--- a/driver/source/co_timer_dummy.c
+++ b/driver/source/co_timer_dummy.c
@@ -18,7 +18,7 @@
 * INCLUDES
 ******************************************************************************/
 
-/* TODO: rename the include file name to match the naming convention: 
+/* TODO: rename the include file name to match the naming convention:
  *   co_timer_<device>.h
  */
 #include "co_timer_dummy.h"
@@ -44,7 +44,7 @@ static void     DrvTimerStop   (void);
 * PUBLIC VARIABLE
 ******************************************************************************/
 
-/* TODO: rename the variable to match the naming convention: 
+/* TODO: rename the variable to match the naming convention:
  *   <device>TimerDriver
  */
 const CO_IF_TIMER_DRV DummyTimerDriver = {
@@ -62,6 +62,8 @@ const CO_IF_TIMER_DRV DummyTimerDriver = {
 
 static void DrvTimerInit(uint32_t freq)
 {
+    (void)freq;
+
     /* TODO: initialize timer, clear counter and keep timer stopped */
 }
 
@@ -84,6 +86,8 @@ static uint32_t DrvTimerDelay(void)
 
 static void DrvTimerReload(uint32_t reload)
 {
+    (void)reload;
+
     /* TODO: reload timer counter value with given reload value */
 }
 

--- a/example/dynamic-od/CMakeLists.txt
+++ b/example/dynamic-od/CMakeLists.txt
@@ -22,21 +22,3 @@ target_include_directories(DynamicOD
 # specify the dependencies for this application
 #
 target_link_libraries(DynamicOD Canopen CanopenDriver)
-
-#---
-# enable warnings and tread as errors
-#
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # tread all files as C files
-    target_compile_options(Quickstart PRIVATE /TC)
-  endif()
-  # enable all warnings
-  target_compile_options(Quickstart PRIVATE -Wall
-                                            -Wextra
-                                            -Wpedantic
-                                            -Werror)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(Quickstart PRIVATE /W4
-                                            /WX)
-endif()

--- a/example/quickstart/CMakeLists.txt
+++ b/example/quickstart/CMakeLists.txt
@@ -21,21 +21,3 @@ target_include_directories(Quickstart
 # specify the dependencies for this application
 #
 target_link_libraries(Quickstart Canopen CanopenDriver)
-
-#---
-# enable warnings and tread as errors
-#
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # tread all files as C files 
-    target_compile_options(Quickstart PRIVATE /TC)
-  endif()
-  # enable all warnings
-  target_compile_options(Quickstart PRIVATE -Wall
-                                            -Wextra
-                                            -Wpedantic
-                                            -Werror)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(Quickstart PRIVATE /W4
-                                            /WX)
-endif()

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -75,21 +75,3 @@ target_include_directories(CanopenTest
 # specify the dependencies for this application
 #
 target_link_libraries(CanopenTest Canopen CanopenDriver)
-
-#---
-# enable warnings and tread as errors
-#
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # tread all files as C files 
-    target_compile_options(CanopenTest PRIVATE /TC)
-  endif()
-  # enable all warnings
-  # target_compile_options(CanopenTest PRIVATE -Wall
-  #                                            -Wextra
-  #                                            -Wpedantic
-  #                                            -Werror)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(CanopenTest PRIVATE /W4
-                                             /WX)
-endif()

--- a/testsuite/testfrm/ts_env.c
+++ b/testsuite/testfrm/ts_env.c
@@ -295,7 +295,7 @@ static void TS_SummaryInit(void)
 static int32_t TS_Summary(void)
 {
     int32_t result = TestData.Sum.FailCnt;
-    
+
     TS_Printf("-----------------------\n");
     TS_Printf("    S U M M A R Y\n");
     TS_Printf("-----------------------\n");
@@ -308,7 +308,7 @@ static int32_t TS_Summary(void)
     } else {
         TS_Printf("FAIL\n");
     }
-    
+
     if (!TS_IsAllEnabled()) {
         TS_Printf("Info: Some Tests are disabled.\n");
     }
@@ -514,7 +514,6 @@ void TS_Init (void)
 int32_t TS_Start (void)
 {
     int32_t            result = 0;
-#if defined ( _MSC_VER )
     const TS_INFOFUNC *test;
     TS_INFO            Info;
 
@@ -534,13 +533,6 @@ int32_t TS_Start (void)
     }
 
     result = TS_Summary();                            /* show test summary statistic              */
-#else
-/* 
-* \note  The testsuite is running with MSVC compiler on the windows host, only. You may
-*        adjust the settings in ts_types.h and provide an output channel in ts_output.c
-*        to get the tests running on your target, too.
-*/
-#endif
 
     return (result);
 }

--- a/testsuite/testfrm/ts_env.h
+++ b/testsuite/testfrm/ts_env.h
@@ -112,7 +112,7 @@ extern "C" {
 *
 *             #### Test Execution Context
 *
-*             Test execution takes place in the main() function. This implies the C runtime 
+*             Test execution takes place in the main() function. This implies the C runtime
 *             stack is used for running the test framework. When creating test case functions,
 *             the test framework provides different runtime contexts for test execution.
 *
@@ -186,7 +186,7 @@ extern "C" {
 */
 /*------------------------------------------------------------------------------------------------*/
 #define TS_GROUP_MAX   16
-    
+
 /******************************************************************************
 * PUBLIC TYPES
 ******************************************************************************/
@@ -289,6 +289,7 @@ typedef void(*TS_INFOFUNC)(TS_INFO *);
     }                                                                         \
     TEST_SECTION_DEF                                                          \
     static TEST_SECTION_PRE TS_INFOFUNC Ptr = TestSuiteInfo TEST_SECTION_SUF; \
+    uintptr_t UnusedDummy##group##suite = (uintptr_t)&Ptr;                    \
     static void TestSuiteRunner(void)
 
 /*------------------------------------------------------------------------------------------------*/
@@ -378,7 +379,7 @@ void TS_Finish (void);
 * \param   line
 *          Line number of check for expected value(s)
 */
-/*------------------------------------------------------------------------------------------------*/    
+/*------------------------------------------------------------------------------------------------*/
 void TS_Fail(TS_LITERAL message, TS_LINE line);
 
 /*------------------------------------------------------------------------------------------------*/

--- a/testsuite/testfrm/ts_output.c
+++ b/testsuite/testfrm/ts_output.c
@@ -37,10 +37,12 @@ void TS_PutChar(void *arg, char character)
     (void)arg;
     putchar((int)character);
 #else
-/* 
+/*
 * \note  The testsuite is running with MSVC compiler on the windows host, only. You may
 *        adjust the settings ts_types.h and provide an output channel here to get the tests
 *        running on your target, too.
 */
+    (void)arg;
+    (void)character;
 #endif
 }

--- a/testsuite/testfrm/ts_types.h
+++ b/testsuite/testfrm/ts_types.h
@@ -59,7 +59,7 @@ typedef unsigned int        uintptr_t;
 ******************************************************************************/
 
 #if defined ( _MSC_VER )
-#define TEST_SECTION_PRE          __declspec(allocate(".test$u")) 
+#define TEST_SECTION_PRE          __declspec(allocate(".test$u"))
 #define TEST_SECTION_DEF          __pragma(section(".test$u", read))
 #define TEST_SECTION_SUF
 #define TEST_SECTION_START        __start_test
@@ -67,26 +67,26 @@ typedef unsigned int        uintptr_t;
 #define TEST_SECTION_START_DEF    __pragma(section(".test$a", read))
 #define TEST_SECTION_START_ALLOC  __declspec(allocate(".test$a")) static const TS_INFOFUNC TEST_SECTION_START = (TS_INFOFUNC)0;
 #define TEST_SECTION_END_DEF      __pragma(section(".test$z", read))
-#define TEST_SECTION_END_ALLOC    __declspec(allocate(".test$z")) static const TS_INFOFUNC TEST_SECTION_END   = (TS_INFOFUNC)0;
+#define TEST_SECTION_END_ALLOC    __declspec(allocate(".test$z")) static const TS_INFOFUNC TEST_SECTION_END = (TS_INFOFUNC)0;
 #define STRUCT_PACKED_PRE         __pragma(pack(push, 1))
 #define STRUCT_PACKED_SUF         __pragma(pack(pop))
 #else
-/* 
+/*
 * \note  The testsuite is running with MSVC compiler on the windows host, only. You may
 *        adjust the settings here and provide an output channel in ts_output.c to get
 *        the tests running on your target, too.
 */
-#define TEST_SECTION_PRE
+#define TEST_SECTION_PRE          __attribute__((section(".test")))
 #define TEST_SECTION_DEF
 #define TEST_SECTION_SUF
-#define TEST_SECTION_START
-#define TEST_SECTION_END
+#define TEST_SECTION_START        __start_test
+#define TEST_SECTION_END          __stop_test
 #define TEST_SECTION_START_DEF
-#define TEST_SECTION_START_ALLOC
+#define TEST_SECTION_START_ALLOC  static const TS_INFOFUNC TEST_SECTION_START = (TS_INFOFUNC)0;
 #define TEST_SECTION_END_DEF
-#define TEST_SECTION_END_ALLOC
+#define TEST_SECTION_END_ALLOC    static const TS_INFOFUNC TEST_SECTION_END = (TS_INFOFUNC)0;
 #define STRUCT_PACKED_PRE
-#define STRUCT_PACKED_SUF
+#define STRUCT_PACKED_SUF         __attribute__((packed))
 #endif
 
 #endif /* TYPES_H_ */

--- a/testsuite/tests/def_suite.h
+++ b/testsuite/tests/def_suite.h
@@ -40,14 +40,15 @@ typedef enum DEF_TEST_GROUPS_E {                      /*---- Test Groups -------
     DEF_G_NUM                                         /*!< Number of Groups                       */
 } DEF_TEST_GROUPS;
 
-typedef enum DEF_CORE_SUITES_E {                      /*---- Core Component Test Suites ----------*/ 
+typedef enum DEF_CORE_SUITES_E {                      /*---- Core Component Test Suites ----------*/
     DEF_S_CORE_TMR,                                   /*!< Suite: Highspeed Timer                 */
     DEF_S_GET_TICKS,                                  /*!< Suite: CoTmrGetTicks()                 */
+    DEF_S_MIN_TIME,                                   /*!< Suite: COTmrGetMinTime()               */
 
     DEF_S_CORE_NUM                                    /*!< Number of Suites in Group              */
 } DEF_CORE_SUITES;
 
-typedef enum DEF_SDOS_SUITES_E {                      /*---- SDO Server Test Suites --------------*/ 
+typedef enum DEF_SDOS_SUITES_E {                      /*---- SDO Server Test Suites --------------*/
     DEF_S_EXP_UP,                                     /*!< Suite: SDO Expedited Upload            */
     DEF_S_EXP_DOWN,                                   /*!< Suite: SDO Expedited Download          */
     DEF_S_SEG_UP,                                     /*!< Suite: SDO Segmented Upload            */
@@ -58,7 +59,7 @@ typedef enum DEF_SDOS_SUITES_E {                      /*---- SDO Server Test Sui
     DEF_S_SDOS_NUM                                    /*!< Number of Suites in Group              */
 } DEF_SDOS_SUITES;
 
-typedef enum DEF_PDO_SUITES_E {                       /*---- PDO Communication Test Suites -------*/ 
+typedef enum DEF_PDO_SUITES_E {                       /*---- PDO Communication Test Suites -------*/
     DEF_S_PDO_TX,                                     /*!< Suite: PDO Transmit                    */
     DEF_S_PDO_RX,                                     /*!< Suite: PDO Receive                     */
     DEF_S_PDO_DYN,                                    /*!< Suite: Dynamic PDO Configuration       */
@@ -66,7 +67,7 @@ typedef enum DEF_PDO_SUITES_E {                       /*---- PDO Communication T
     DEF_S_PDO_NUM                                     /*!< Number of Suites in Group              */
 } DEF_PDO_SUITES;
 
-typedef enum DEF_NMT_SUITES_E {                       /*---- NMT Management Test Suites ----------*/ 
+typedef enum DEF_NMT_SUITES_E {                       /*---- NMT Management Test Suites ----------*/
     DEF_S_NMT_MGR,                                    /*!< Suite: NMT Management                  */
     DEF_S_NMT_HBP,                                    /*!< Suite: NMT Heartbeat Producer          */
     DEF_S_NMT_HBC,                                    /*!< Suite: NMT Heartbeat Consumer          */
@@ -75,7 +76,7 @@ typedef enum DEF_NMT_SUITES_E {                       /*---- NMT Management Test
     DEF_S_NMT_NUM                                     /*!< Number of Suites in Group              */
 } DEF_NMT_SUITES;
 
-typedef enum DEF_EMCY_SUITES_E {                      /*---- EMCY Management Test Suites ---------*/ 
+typedef enum DEF_EMCY_SUITES_E {                      /*---- EMCY Management Test Suites ---------*/
     DEF_S_EMCY_STATE,                                 /*!< Suite: EMCY Error States               */
     DEF_S_EMCY_ERR,                                   /*!< Suite: EMCY Error Register Object      */
     DEF_S_EMCY_HIST,                                  /*!< Suite: EMCY Error History Object       */
@@ -88,8 +89,9 @@ typedef enum DEF_EMCY_SUITES_E {                      /*---- EMCY Management Tes
 * PUBLIC DEFINES
 ******************************************************************************/
 
-#define SUITE_CORE_TMR()   TS_DEF_SUITE(DEF_G_CORE, DEF_S_CORE_TMR)  /*!< \addtogroup core_tmr      Core Timer Test  */
-#define SUITE_GET_TICKS()  TS_DEF_SUITE(DEF_G_CORE, DEF_S_GET_TICKS) /*!< \addtogroup co_tmr      Timer Service Test  */
+#define SUITE_CORE_TMR()   TS_DEF_SUITE(DEF_G_CORE, DEF_S_CORE_TMR)  /*!< \addtogroup core_tmr    Core Timer Test     */
+#define SUITE_GET_TICKS()  TS_DEF_SUITE(DEF_G_CORE, DEF_S_GET_TICKS) /*!< \addtogroup co_get_tick Timer Service Test  */
+#define SUITE_MIN_TIME()   TS_DEF_SUITE(DEF_G_CORE, DEF_S_MIN_TIME)  /*!< \addtogroup co_min_tmr  Get Timer Min Time  */
 
 #define SUITE_EXP_UP()     TS_DEF_SUITE(DEF_G_SDOS, DEF_S_EXP_UP)    /*!< \addtogroup sdos_exp_up   SDO Server Test: Expedited Upload   */
 #define SUITE_EXP_DOWN()   TS_DEF_SUITE(DEF_G_SDOS, DEF_S_EXP_DOWN)  /*!< \addtogroup sdos_exp_down SDO Server Test: Expedited Download */

--- a/testsuite/tests/get_min_time.c
+++ b/testsuite/tests/get_min_time.c
@@ -106,7 +106,7 @@ static void Setup(void)
     TS_CreateMandatoryDir();
 }
 
-SUITE_GET_TICKS()
+SUITE_MIN_TIME()
 {
     TS_Begin(__FILE__);
     TS_SetupCase(Setup, NULL);

--- a/testsuite/tests/sdos_exp_down.c
+++ b/testsuite/tests/sdos_exp_down.c
@@ -42,7 +42,7 @@
 *   - ok     : correct SDO request
 *   - badcmd : bad SDO command in request
 *
-* #### Test Definition 
+* #### Test Definition
 *
 * test-function                  | obj    | size    | prop    | req    | type
 * ------------------------------ | ------ | ------- | ------- | ------ | ----
@@ -75,6 +75,22 @@
 * PRIVATE FUNCTIONS
 ******************************************************************************/
 
+#define MY_TYPE  ((CO_OBJ_TYPE *)&MyType)
+
+static CO_ERR MyTypeWriteErr(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *buf, uint32_t size)
+{
+    CO_ERR err = CO_ERR_TYPE_WR;
+
+    COObjTypeUserSDOAbort(obj, node, 0x11223344);
+
+    (void)size;
+    (void)buf;
+
+    return (err);
+}
+
+static const CO_OBJ_TYPE MyType = { 0, 0, 0, MyTypeWriteErr };
+
 /*------------------------------------------------------------------------------------------------*/
 /*!
 * \brief    Write a parameter byte to object dictionary
@@ -96,10 +112,10 @@
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_1BytePara)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 1;
-    uint8_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 1;
+    uint8_t  val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -138,10 +154,10 @@ TS_DEF_MAIN(TS_ExpWr_1BytePara)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_2BytePara)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 2;
-    uint16_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 2;
+    uint16_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -180,10 +196,10 @@ TS_DEF_MAIN(TS_ExpWr_2BytePara)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_4BytePara)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 3;
-    uint32_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 3;
+    uint32_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -222,10 +238,10 @@ TS_DEF_MAIN(TS_ExpWr_4BytePara)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_1ByteVar)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 1;
-    uint8_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2500;
+    uint8_t  sub  = 1;
+    uint8_t  val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -264,10 +280,10 @@ TS_DEF_MAIN(TS_ExpWr_1ByteVar)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_2ByteVar)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 2;
-    uint16_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2500;
+    uint8_t  sub  = 2;
+    uint16_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -306,10 +322,10 @@ TS_DEF_MAIN(TS_ExpWr_2ByteVar)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_4ByteVar)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 3;
-    uint32_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2500;
+    uint8_t  sub  = 3;
+    uint32_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -321,7 +337,7 @@ TS_DEF_MAIN(TS_ExpWr_4ByteVar)
 
     /* -- CHECK -- */
     CHK_SDO0_OK(idx, sub);
-    
+
     TS_ASSERT(0x44434241 == val);
 
     CHK_NO_ERR(&node);
@@ -348,10 +364,10 @@ TS_DEF_MAIN(TS_ExpWr_4ByteVar)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_2ByteVar_NoLen)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 1;
-    uint8_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2500;
+    uint8_t  sub  = 1;
+    uint8_t  val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -389,10 +405,10 @@ TS_DEF_MAIN(TS_ExpWr_2ByteVar_NoLen)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_BadCmd)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 3;
-    uint32_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 3;
+    uint32_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -429,10 +445,10 @@ TS_DEF_MAIN(TS_ExpWr_BadCmd)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_ObjNotExist)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2100;
-    uint8_t     sub  = 1;
-    uint32_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2100;
+    uint8_t  sub  = 1;
+    uint32_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -469,10 +485,10 @@ TS_DEF_MAIN(TS_ExpWr_ObjNotExist)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_SubIdxNotExist)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2100;
-    uint8_t     sub  = 0;
-    uint32_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2100;
+    uint8_t  sub  = 0;
+    uint32_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -509,10 +525,10 @@ TS_DEF_MAIN(TS_ExpWr_SubIdxNotExist)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_ReadOnly)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 6;
-    uint16_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 6;
+    uint16_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -548,10 +564,10 @@ TS_DEF_MAIN(TS_ExpWr_ReadOnly)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_LenTooHigh)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 2;
-    uint16_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 2;
+    uint16_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -587,10 +603,10 @@ TS_DEF_MAIN(TS_ExpWr_LenTooHigh)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_LenTooLow)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 2;
-    uint16_t     val  = 0;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 2;
+    uint16_t val  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -627,9 +643,9 @@ TS_DEF_MAIN(TS_ExpWr_LenTooLow)
 /*------------------------------------------------------------------------------------------------*/
 TS_DEF_MAIN(TS_ExpWr_DataNullPtr)
 {
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 7;
+    CO_NODE  node;
+    uint16_t idx  = 0x2510;
+    uint8_t  sub  = 7;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -641,6 +657,47 @@ TS_DEF_MAIN(TS_ExpWr_DataNullPtr)
 
     /* -- CHECK -- */
     CHK_SDO0_ERR(idx, sub, 0x08000020);
+
+    CHK_NO_ERR(&node);
+}
+
+/*------------------------------------------------------------------------------------------------*/
+/*!
+* \brief    Try to write with an error in type function to an object dictionary
+*
+* \details  This test checks, that the type function write() can abort with a user defined code.
+*
+* ####      Test Preparation
+*           1. Prepare object dictionary including a variable of type MY_TYPE.
+*
+* ####      Test Steps
+*           1. Send SDO expedited download request initiating a type error
+*
+* ####      Test Checks
+*           1. Check, that SDO server response is correct
+*           2. Check, that value is not written in object dictionary
+*           3. Check, that CANopen stack executes this error free
+*/
+/*------------------------------------------------------------------------------------------------*/
+TS_DEF_MAIN(TS_ExpWr_UserWriteErr)
+{
+    CO_NODE  node;
+    uint16_t idx  = 0x2500;
+    uint8_t  sub  = 1;
+    uint8_t  val  = 0;
+
+    /* -- PREPARATION -- */
+    TS_CreateMandatoryDir();
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), MY_TYPE, (uintptr_t)&val);
+    TS_CreateNode(&node,0);
+
+    /* -- TEST -- */
+    TS_SDO_SEND (0x2F, idx, sub, 0);
+
+    /* -- CHECK -- */
+    CHK_SDO0_ERR(idx, sub, 0x11223344);
+
+    TS_ASSERT(0 == val);
 
     CHK_NO_ERR(&node);
 }
@@ -670,6 +727,8 @@ SUITE_EXP_DOWN()
     TS_RUNNER(TS_ExpWr_LenTooHigh);
     TS_RUNNER(TS_ExpWr_LenTooLow);
     TS_RUNNER(TS_ExpWr_DataNullPtr);
+
+    TS_RUNNER(TS_ExpWr_UserWriteErr);
 
 //    CanDiagnosticOff(0);
 

--- a/testsuite/tests/sdos_exp_up.c
+++ b/testsuite/tests/sdos_exp_up.c
@@ -41,7 +41,7 @@
 *   - ok     : correct SDO request
 *   - badcmd : bad SDO command in request
 *
-* #### Test Definition 
+* #### Test Definition
 *
 * test-function                  | obj    | size    | prop    | req    | type
 * ------------------------------ | ------ | ------- | ------- | ------ | ----
@@ -74,6 +74,22 @@
 * PRIVATE FUNCTIONS
 ******************************************************************************/
 
+#define MY_TYPE  ((CO_OBJ_TYPE *)&MyType)
+
+static CO_ERR MyTypeReadErr(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *buf, uint32_t size)
+{
+    CO_ERR err = CO_ERR_TYPE_RD;
+
+    COObjTypeUserSDOAbort(obj, node, 0x11223344);
+
+    (void)size;
+    (void)buf;
+
+    return (err);
+}
+
+static const CO_OBJ_TYPE MyType = { 0, 0, MyTypeReadErr, 0 };
+
 /*------------------------------------------------------------------------------------------------*/
 /*!
 * \brief    Read a parameter byte from object dictionary
@@ -96,10 +112,10 @@
 TS_DEF_MAIN(TS_ExpRd_1BytePara)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 1;
-    uint8_t     val  = 0x11;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2510;
+    uint8_t   sub  = 1;
+    uint8_t   val  = 0x11;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -141,10 +157,10 @@ TS_DEF_MAIN(TS_ExpRd_1BytePara)
 TS_DEF_MAIN(TS_ExpRd_2BytePara)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 2;
-    uint16_t     val  = 0x2221;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2510;
+    uint8_t   sub  = 2;
+    uint16_t  val  = 0x2221;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -152,7 +168,7 @@ TS_DEF_MAIN(TS_ExpRd_2BytePara)
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
-    TS_SDO_SEND (0x40, idx, sub, 0x00000000); 
+    TS_SDO_SEND (0x40, idx, sub, 0x00000000);
 
     /* -- CHECK -- */
     CHK_CAN  (&frm);
@@ -186,10 +202,10 @@ TS_DEF_MAIN(TS_ExpRd_2BytePara)
 TS_DEF_MAIN(TS_ExpRd_4BytePara)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 3;
-    uint32_t     val  = 0x44434241;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2510;
+    uint8_t   sub  = 3;
+    uint32_t  val  = 0x44434241;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -231,10 +247,10 @@ TS_DEF_MAIN(TS_ExpRd_4BytePara)
 TS_DEF_MAIN(TS_ExpRd_1ByteVar)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 1;
-    uint8_t     val  = 0x11;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2500;
+    uint8_t   sub  = 1;
+    uint8_t   val  = 0x11;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -276,10 +292,10 @@ TS_DEF_MAIN(TS_ExpRd_1ByteVar)
 TS_DEF_MAIN(TS_ExpRd_2ByteVar)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 2;
-    uint16_t     val  = 0x2221;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2500;
+    uint8_t   sub  = 2;
+    uint16_t  val  = 0x2221;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -320,10 +336,10 @@ TS_DEF_MAIN(TS_ExpRd_2ByteVar)
 TS_DEF_MAIN(TS_ExpRd_4ByteVar)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 3;
-    uint32_t     val  = 0x44434241;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2500;
+    uint8_t   sub  = 3;
+    uint32_t  val  = 0x44434241;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -365,9 +381,9 @@ TS_DEF_MAIN(TS_ExpRd_4ByteVar)
 TS_DEF_MAIN(TS_ExpRd_4ByteConst)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2505;
-    uint8_t     sub  = 3;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2505;
+    uint8_t   sub  = 3;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -410,9 +426,9 @@ TS_DEF_MAIN(TS_ExpRd_4ByteConst)
 TS_DEF_MAIN(TS_ExpRd_4ByteConstNodeId)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2505;
-    uint8_t     sub  = 3;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2505;
+    uint8_t   sub  = 3;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -455,10 +471,10 @@ TS_DEF_MAIN(TS_ExpRd_4ByteConstNodeId)
 TS_DEF_MAIN(TS_ExpRd_2ByteParaNodeId)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 6;
-    uint16_t     val  = 0x2221;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2510;
+    uint8_t   sub  = 6;
+    uint16_t  val  = 0x2221;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -500,10 +516,10 @@ TS_DEF_MAIN(TS_ExpRd_2ByteParaNodeId)
 TS_DEF_MAIN(TS_ExpRd_BadCmd)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2510;
-    uint8_t     sub  = 3;
-    uint16_t     val  = 0x2221;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2510;
+    uint8_t   sub  = 3;
+    uint16_t  val  = 0x2221;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -546,9 +562,9 @@ TS_DEF_MAIN(TS_ExpRd_BadCmd)
 TS_DEF_MAIN(TS_ExpRd_ObjNotExist)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2180;
-    uint8_t     sub  = 0;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2180;
+    uint8_t   sub  = 0;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -589,10 +605,10 @@ TS_DEF_MAIN(TS_ExpRd_ObjNotExist)
 TS_DEF_MAIN(TS_ExpRd_SubIdxNotExist)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2505;
-    uint8_t     sub  = 0;
-    uint16_t     val  = 0x2221;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2505;
+    uint8_t   sub  = 0;
+    uint16_t  val  = 0x2221;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -635,10 +651,10 @@ TS_DEF_MAIN(TS_ExpRd_SubIdxNotExist)
 TS_DEF_MAIN(TS_ExpRd_WriteOnly)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2505;
-    uint8_t     sub  = 5;
-    uint16_t     val  = 0x2221;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2505;
+    uint8_t   sub  = 5;
+    uint16_t  val  = 0x2221;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -681,9 +697,9 @@ TS_DEF_MAIN(TS_ExpRd_WriteOnly)
 TS_DEF_MAIN(TS_ExpRd_DataNullPtr)
 {
     CO_IF_FRM frm;
-    CO_NODE        node;
-    uint16_t     idx  = 0x2500;
-    uint8_t     sub  = 4;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2500;
+    uint8_t   sub  = 4;
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
@@ -703,6 +719,51 @@ TS_DEF_MAIN(TS_ExpRd_DataNullPtr)
     CHK_NO_ERR(&node);
 }
 
+/*------------------------------------------------------------------------------------------------*/
+/*!
+* \brief    Response to a bad SDO expedited upload request command
+*
+* \details  This test will check, that the Abort code "Client/server command specifier not valid
+*           or unknown" (abort code 0x05040001) is sent to a SDO request with a bad command byte.
+*
+* ####      Test Preparation
+*           none
+*
+* ####      Test Steps
+*           1. Send SDO expedited upload request with bad command
+*
+* ####      Test Checks
+*           1. Check, that SDO server send a response
+*           2. Check, that SDO server aborts the request
+*           3. Check, that CANopen stack executes this error free
+*/
+/*------------------------------------------------------------------------------------------------*/
+TS_DEF_MAIN(TS_ExpRd_UserReadErr)
+{
+    CO_IF_FRM frm;
+    CO_NODE   node;
+    uint16_t  idx  = 0x2510;
+    uint8_t   sub  = 3;
+    uint16_t  val  = 0x1234;
+
+    /* -- PREPARATION -- */
+    TS_CreateMandatoryDir();
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), MY_TYPE, (uintptr_t)&val);
+    TS_CreateNode(&node,0);
+
+    /* -- TEST -- */
+    TS_SDO_SEND (0x40, idx, sub, 0);
+
+    /* -- CHECK -- */
+    CHK_CAN  (&frm);
+
+    CHK_SDO0 (frm, 0x80);
+    CHK_MLTPX(frm, idx, sub);
+    CHK_DATA (frm, 0x11223344);
+
+    CHK_NO_ERR(&node);
+}
+
 /******************************************************************************
 * PUBLIC FUNCTIONS
 ******************************************************************************/
@@ -710,7 +771,7 @@ TS_DEF_MAIN(TS_ExpRd_DataNullPtr)
 SUITE_EXP_UP()
 {
     TS_Begin(__FILE__);
-    
+
 //    CanDiagnosticOn(0);
 
     TS_RUNNER(TS_ExpRd_1BytePara);
@@ -722,12 +783,14 @@ SUITE_EXP_UP()
     TS_RUNNER(TS_ExpRd_4ByteConst);
     TS_RUNNER(TS_ExpRd_4ByteConstNodeId);
     TS_RUNNER(TS_ExpRd_2ByteParaNodeId);
-    
+
     TS_RUNNER(TS_ExpRd_BadCmd);
     TS_RUNNER(TS_ExpRd_ObjNotExist);
     TS_RUNNER(TS_ExpRd_SubIdxNotExist);
     TS_RUNNER(TS_ExpRd_WriteOnly);
     TS_RUNNER(TS_ExpRd_DataNullPtr);
+
+    TS_RUNNER(TS_ExpRd_UserReadErr);
 
 //    CanDiagnosticOff(0);
 

--- a/tools/cmake/toolchain/toolchain-gcc_cortex-m3.cmake
+++ b/tools/cmake/toolchain/toolchain-gcc_cortex-m3.cmake
@@ -1,0 +1,94 @@
+#******************************************************************************
+#  Copyright 2020 Embedded Office GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#*****************************************************************************
+
+# The Generic system name is used for embedded targets in CMake
+set(CMAKE_SYSTEM_NAME      Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Because the cross-compiler cannot directly generate a binary without
+# complaining, just test compiling a static library instead of an executable
+# program
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+
+#*****************************************************************************
+#* Define commands
+
+set(CMAKE_C_COMPILER   "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_LINKER       "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_OBJCOPY      "arm-none-eabi-objcopy.exe" CACHE FILEPATH "" FORCE)
+set(CMAKE_OBJDUMP      "arm-none-eabi-objdump.exe" CACHE FILEPATH "" FORCE)
+
+
+#*****************************************************************************
+#* Defince command line options
+
+set(CMAKE_C_FLAGS
+  "-mthumb -mcpu=cortex-m3 -mfloat-abi=softfp -Wall -Wextra -Wpedantic -Werror"
+  CACHE STRING "" FORCE
+)
+set(CMAKE_ASM_FLAGS
+  "${CMAKE_C_FLAGS} -x assembler-with-cpp"
+  CACHE STRING "" FORCE
+)
+set(
+  CMAKE_EXE_LINKER_FLAGS
+  "-mthumb -mcpu=cortex-m3 -mfloat-abi=softfp -nostartfiles"
+  CACHE STRING "" FORCE
+)
+
+# additional flags depending on the config command line switch
+set(CMAKE_C_FLAGS_DEBUG          # --config Debug
+  "-O0 -g -gdwarf-2"
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_RELEASE        # --config Release
+  "-O2"
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_MINSIZEREL     # --config MinSizeRel
+  ""
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_RELWITHDEBINFO # --config RelWithDebInfo
+  ""
+  CACHE STRING ""
+)
+
+# setup standard flags
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+
+#*****************************************************************************
+#* functions for application specific appending of mapfile and linker script
+
+function(setOutfile target filename)
+  set_target_properties(${target} PROPERTIES OUTPUT_NAME "${filename}")
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map,${filename}.map -Xlinker --cref"
+    CACHE STRING "" FORCE
+  )
+endfunction()
+
+function(setLinkerScript target filename)
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -T ${filename}.lds"
+    CACHE STRING "" FORCE
+  )
+endfunction()

--- a/tools/cmake/toolchain/toolchain-gcc_cortex-m4.cmake
+++ b/tools/cmake/toolchain/toolchain-gcc_cortex-m4.cmake
@@ -1,0 +1,94 @@
+#******************************************************************************
+#  Copyright 2020 Embedded Office GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#*****************************************************************************
+
+# The Generic system name is used for embedded targets in CMake
+set(CMAKE_SYSTEM_NAME      Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Because the cross-compiler cannot directly generate a binary without
+# complaining, just test compiling a static library instead of an executable
+# program
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+
+#*****************************************************************************
+#* Define commands
+
+set(CMAKE_C_COMPILER   "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_LINKER       "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_OBJCOPY      "arm-none-eabi-objcopy.exe" CACHE FILEPATH "" FORCE)
+set(CMAKE_OBJDUMP      "arm-none-eabi-objdump.exe" CACHE FILEPATH "" FORCE)
+
+
+#*****************************************************************************
+#* Defince command line options
+
+set(CMAKE_C_FLAGS
+  "-mthumb -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -Wall -Wextra -Wpedantic -Werror"
+  CACHE STRING "" FORCE
+)
+set(CMAKE_ASM_FLAGS
+  "${CMAKE_C_FLAGS} -x assembler-with-cpp"
+  CACHE STRING "" FORCE
+)
+set(
+  CMAKE_EXE_LINKER_FLAGS
+  "-mthumb -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -nostartfiles"
+  CACHE STRING "" FORCE
+)
+
+# additional flags depending on the config command line switch
+set(CMAKE_C_FLAGS_DEBUG          # --config Debug
+  "-O0 -g -gdwarf-2"
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_RELEASE        # --config Release
+  "-O2"
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_MINSIZEREL     # --config MinSizeRel
+  ""
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_RELWITHDEBINFO # --config RelWithDebInfo
+  ""
+  CACHE STRING ""
+)
+
+# setup standard flags
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+
+#*****************************************************************************
+#* functions for application specific appending of mapfile and linker script
+
+function(setOutfile target filename)
+  set_target_properties(${target} PROPERTIES OUTPUT_NAME "${filename}")
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map,${filename}.map -Xlinker --cref"
+    CACHE STRING "" FORCE
+  )
+endfunction()
+
+function(setLinkerScript target filename)
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -T ${filename}.lds"
+    CACHE STRING "" FORCE
+  )
+endfunction()

--- a/tools/cmake/toolchain/toolchain-gcc_cortex-m7.cmake
+++ b/tools/cmake/toolchain/toolchain-gcc_cortex-m7.cmake
@@ -1,0 +1,94 @@
+#******************************************************************************
+#  Copyright 2020 Embedded Office GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#*****************************************************************************
+
+# The Generic system name is used for embedded targets in CMake
+set(CMAKE_SYSTEM_NAME      Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Because the cross-compiler cannot directly generate a binary without
+# complaining, just test compiling a static library instead of an executable
+# program
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+
+#*****************************************************************************
+#* Define commands
+
+set(CMAKE_C_COMPILER   "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_LINKER       "arm-none-eabi-gcc.exe"     CACHE FILEPATH "" FORCE)
+set(CMAKE_OBJCOPY      "arm-none-eabi-objcopy.exe" CACHE FILEPATH "" FORCE)
+set(CMAKE_OBJDUMP      "arm-none-eabi-objdump.exe" CACHE FILEPATH "" FORCE)
+
+
+#*****************************************************************************
+#* Defince command line options
+
+set(CMAKE_C_FLAGS
+  "-mthumb -mcpu=cortex-m7 -mfpu=fpv5-sp-d16 -Wall -Wextra -Wpedantic -Werror"
+  CACHE STRING "" FORCE
+)
+set(CMAKE_ASM_FLAGS
+  "${CMAKE_C_FLAGS} -x assembler-with-cpp"
+  CACHE STRING "" FORCE
+)
+set(
+  CMAKE_EXE_LINKER_FLAGS
+  "-mthumb -mcpu=cortex-m7 -mfpu=fpv5-sp-d16 -nostartfiles"
+  CACHE STRING "" FORCE
+)
+
+# additional flags depending on the config command line switch
+set(CMAKE_C_FLAGS_DEBUG          # --config Debug
+  "-O0 -g -gdwarf-2"
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_RELEASE        # --config Release
+  "-O2"
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_MINSIZEREL     # --config MinSizeRel
+  ""
+  CACHE STRING ""
+)
+set(CMAKE_C_FLAGS_RELWITHDEBINFO # --config RelWithDebInfo
+  ""
+  CACHE STRING ""
+)
+
+# setup standard flags
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+
+#*****************************************************************************
+#* functions for application specific appending of mapfile and linker script
+
+function(setOutfile target filename)
+  set_target_properties(${target} PROPERTIES OUTPUT_NAME "${filename}")
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map,${filename}.map -Xlinker --cref"
+    CACHE STRING "" FORCE
+  )
+endfunction()
+
+function(setLinkerScript target filename)
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -T ${filename}.lds"
+    CACHE STRING "" FORCE
+  )
+endfunction()


### PR DESCRIPTION
This last-minute pull request introduces an API function that allows us to define a manufacturer-specific SDO Abort code with the type functions read/write.

In addition, we do some small steps forward for our convenience with target-specific CMake toolchain files.