### PR TITLE
[FEATURE] Added SYNC producer functionality

### DIFF
--- a/canopen/include/co_err.h
+++ b/canopen/include/co_err.h
@@ -102,6 +102,7 @@ typedef enum CO_ERR_T {
     CO_ERR_SDO_WRITE,            /*!< error during in SDO block writing      */
 
     CO_ERR_SYNC_MSG,             /*!< error during receive synchronous PDO   */
+    CO_ERR_SYNC_RES,             /*!< SYNC cycle is out of resolution        */
 
     CO_ERR_IF_CAN_INIT,          /*!< error during initialization            */
     CO_ERR_IF_CAN_ENABLE,        /*!< error during enabling CAN interface    */

--- a/canopen/include/co_err.h
+++ b/canopen/include/co_err.h
@@ -66,6 +66,7 @@ typedef enum CO_ERR_T {
     CO_ERR_CFG_1003_0,           /*!< entry 1003:0 is bad/not existing       */
     CO_ERR_CFG_1003_1,           /*!< entry 1003:1 is bad/not existing       */
     CO_ERR_CFG_1005_0,           /*!< entry 1005:0 is bad/not existing       */
+    CO_ERR_CFG_1006_0,           /*!< entry 1006:0 is bad/not existing       */
     CO_ERR_CFG_1010_0,           /*!< entry 1010:0 is bad/not existing       */
     CO_ERR_CFG_1011_0,           /*!< entry 1011:0 is bad/not existing       */
     CO_ERR_CFG_1014_0,           /*!< entry 1014:0 is bad/not existing       */

--- a/canopen/include/co_sync.h
+++ b/canopen/include/co_sync.h
@@ -38,10 +38,11 @@ extern "C" {
 #define CO_SYNC_COBID_EXT    ((uint32_t)1 << 29)    /*!< extended format     */
 #define CO_SYNC_COBID_MASK   ((uint32_t)0x1FFFFFFF) /*!< identifier mask     */
 
-#define CO_SYNC_FLG_TX    0x01    /*!< message type indication  TPDO         */
-#define CO_SYNC_FLG_RX    0x02    /*!< message type indication: RPDO         */
+#define CO_SYNC_FLG_TX       (0x01) /*!< message type indication  TPDO       */
+#define CO_SYNC_FLG_RX       (0x02) /*!< message type indication: RPDO       */
 
-#define CO_TSYNCID ((const CO_OBJ_TYPE *)&COTSyncId)  /*!< Dynamic COB-ID    */
+#define CO_TSYNCID ((const CO_OBJ_TYPE *)&COTSyncId) /*!< Dynamic COB-ID     */
+#define CO_TSYNCCT ((const CO_OBJ_TYPE *)&COTSyncCycle) /*!< Dynamic cycle   */
 
 /******************************************************************************
 * PUBLIC CONSTANTS
@@ -54,6 +55,8 @@ extern "C" {
 *    the sync cob-id value and sync producer functionality.
 */
 extern const CO_OBJ_TYPE COTSyncId;
+
+extern const CO_OBJ_TYPE COTSyncCycle;
 
 /******************************************************************************
 * PUBLIC TYPES
@@ -226,6 +229,29 @@ void COSyncProdSend(void *parg);
 * \retval  CO_ERR_OBJ_RANGE   an error is detected and function aborted
 */
 CO_ERR COTypeSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *buf, uint32_t len);
+
+/*! \brief SYNC COMMUNICATION CYCLE WRITE ACCESS
+*
+*    This function is responsible for the correct write access for the
+*    SYNC communication cycle object entry (1006h). Value is presented
+*    as number of microseconds.
+*
+* \param obj
+*    SYNC communication cycle entry reference
+*
+* \param node
+*    reference to parent node
+*
+* \param buf
+*    Pointer to buffer memory
+*
+* \param len
+*    Length of buffer memory
+*
+* \retval  CO_ERR_NONE        SYNC COB-ID object entry is written
+* \retval  CO_ERR_OBJ_RANGE   an error is detected and function aborted
+*/
+CO_ERR COTypeSyncCycleWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *buf, uint32_t len);
 
 /******************************************************************************
 * CALLBACK FUNCTIONS

--- a/canopen/include/co_sync.h
+++ b/canopen/include/co_sync.h
@@ -44,6 +44,18 @@ extern "C" {
 #define CO_TSYNCID ((const CO_OBJ_TYPE *)&COTSyncId)  /*!< Dynamic COB-ID    */
 
 /******************************************************************************
+* PUBLIC CONSTANTS
+******************************************************************************/
+
+/*! \brief OBJECT TYPE SYNC COB-ID
+*
+*    This object type specializes the general handling of object for the
+*    object dictionary entry 0x1005. This entries is designed to provide
+*    the sync cob-id value and sync producer functionality.
+*/
+extern const CO_OBJ_TYPE COTSyncId;
+
+/******************************************************************************
 * PUBLIC TYPES
 ******************************************************************************/
 
@@ -55,6 +67,8 @@ typedef struct CO_SYNC_T {
     struct CO_NODE_T *Node;             /*!< link to parent node             */
     uint32_t          CobId;            /*!< SYNC message identifier         */
     uint32_t          Time;             /*!< SYNC time (num of SYNCs)        */
+    int16_t           Tmr;              /*!< SYNC producer timer ID          */
+    uint32_t          Cycle;            /*!< SYNC producer cycle time (us)   */
     CO_IF_FRM         RFrm[CO_RPDO_N];  /*!< synchronous RPDO CAN frame      */
     struct CO_RPDO_T *RPdo[CO_RPDO_N];  /*!< Pointer to synchronous RPDO     */
     struct CO_TPDO_T *TPdo[CO_TPDO_N];  /*!< Pointer to synchronous TPDO     */
@@ -158,6 +172,37 @@ int16_t COSyncUpdate(CO_SYNC *sync, CO_IF_FRM *frm);
 *    Pointer to SYNC object
 */
 void COSyncRestart(CO_SYNC *sync);
+
+/*! \brief ACTIVATE SYNC PRODUCER
+*
+*    This function is used to activate SYNC producer functionality.
+*    It's called on NMT Start Pre-Operational or sync COB-ID update
+*    (1005h) with bit 30 set to 1.
+*
+* \param sync
+*    Pointer to SYNC object
+*/
+void COSyncProdActivate(CO_SYNC *sync);
+
+/*! \brief ACTIVATE SYNC PRODUCER
+*
+*    This function is used to deactivate SYNC producer functionality.
+*    It's called on sync COB-ID update (1005h) with bit 30 set to 0.
+*
+* \param sync
+*    Pointer to SYNC object
+*/
+void COSyncProdDeactivate(CO_SYNC *sync);
+
+/*! \brief SYNC PRODUCER TRANSMISSION TRIGGER
+ *
+ *   This function is used for periodic transmission of SYNC frames
+ *   in case node is configured as SYNC producer.
+ *
+ * \param parg
+ *    reference to SYNC structure
+ */
+void COSyncProdSend(void *parg);
 
 /*! \brief SYNC COB-ID WRITE ACCESS
 *

--- a/canopen/include/co_sync.h
+++ b/canopen/include/co_sync.h
@@ -34,15 +34,15 @@ extern "C" {
 * PUBLIC DEFINES
 ******************************************************************************/
 
-#define CO_SYNC_COBID_OFF    ((uint32_t)1 << 30)    /*!< generator flag      */
-#define CO_SYNC_COBID_EXT    ((uint32_t)1 << 29)    /*!< extended format     */
-#define CO_SYNC_COBID_MASK   ((uint32_t)0x1FFFFFFF) /*!< identifier mask     */
+#define CO_SYNC_COBID_ON     ((uint32_t)1 << 30)    /*!< generator flag         */
+#define CO_SYNC_COBID_EXT    ((uint32_t)1 << 29)    /*!< extended format        */
+#define CO_SYNC_COBID_MASK   ((uint32_t)0x1FFFFFFF) /*!< identifier mask        */
 
-#define CO_SYNC_FLG_TX       (0x01) /*!< message type indication  TPDO       */
-#define CO_SYNC_FLG_RX       (0x02) /*!< message type indication: RPDO       */
+#define CO_SYNC_FLG_TX       (0x01) /*!< message type indication  TPDO          */
+#define CO_SYNC_FLG_RX       (0x02) /*!< message type indication: RPDO          */
 
-#define CO_TSYNCID ((const CO_OBJ_TYPE *)&COTSyncId) /*!< Dynamic COB-ID     */
-#define CO_TSYNCCT ((const CO_OBJ_TYPE *)&COTSyncCycle) /*!< Dynamic cycle   */
+#define CO_TSYNCID    ((const CO_OBJ_TYPE *)&COTSyncId) /*!< Dynamic COB-ID     */
+#define CO_TSYNCCYCLE ((const CO_OBJ_TYPE *)&COTSyncCycle) /*!< Dynamic cycle   */
 
 /******************************************************************************
 * PUBLIC CONSTANTS
@@ -56,6 +56,12 @@ extern "C" {
 */
 extern const CO_OBJ_TYPE COTSyncId;
 
+/*! \brief OBJECT TYPE SYNC COMMUNICATION CYCLE
+*
+*    This object type specializes the general handling of object for the
+*    object dictionary entry 0x1006. This entries is designed to provide
+*    the sync communication cycle value.
+*/
 extern const CO_OBJ_TYPE COTSyncCycle;
 
 /******************************************************************************

--- a/canopen/source/co_nmt.c
+++ b/canopen/source/co_nmt.c
@@ -138,9 +138,6 @@ void CONmtSetMode(CO_NMT *nmt, CO_MODE mode)
         if (mode == CO_OPERATIONAL) {
             COTPdoInit(nmt->Node->TPdo, nmt->Node);
             CORPdoInit(nmt->Node->RPdo, nmt->Node);
-        } else if (mode == CO_PREOP) {
-            /* Activate SYNC producer if possible */
-            COSyncProdActivate(&nmt->Node->Sync);
         }
         CONmtModeChange(nmt, mode);
     }

--- a/canopen/source/co_nmt.c
+++ b/canopen/source/co_nmt.c
@@ -138,6 +138,9 @@ void CONmtSetMode(CO_NMT *nmt, CO_MODE mode)
         if (mode == CO_OPERATIONAL) {
             COTPdoInit(nmt->Node->TPdo, nmt->Node);
             CORPdoInit(nmt->Node->RPdo, nmt->Node);
+        } else if (mode == CO_PREOP) {
+            /* Activate SYNC producer if possible */
+            COSyncProdActivate(&nmt->Node->Sync);
         }
         CONmtModeChange(nmt, mode);
     }

--- a/canopen/source/co_sync.c
+++ b/canopen/source/co_sync.c
@@ -62,6 +62,8 @@ void COSyncInit(CO_SYNC *sync, struct CO_NODE_T *node)
     if (err != CO_ERR_NONE) {
         sync->CobId = 0;
     }
+
+    COSyncProdActivate(sync);
 }
 
 /*

--- a/canopen/source/co_sync.c
+++ b/canopen/source/co_sync.c
@@ -215,8 +215,8 @@ void COSyncProdActivate(CO_SYNC *sync) {
         return;
     }
 
-    time = COTmrGetMinTime(&node->Tmr, CO_TMR_UNIT_1MS);
-    if ((time * 1000) > sync->Cycle) {
+    time = COTmrGetMinTime(&node->Tmr, CO_TMR_UNIT_100US);
+    if ((time * 100) > sync->Cycle) {
         /* 
          * Provided timer driver has small resolution for configured 
          * value, it is not possible to handle SYNCs on requested 
@@ -236,9 +236,9 @@ void COSyncProdActivate(CO_SYNC *sync) {
         }
     }
 
-    time = (sync->Cycle / 1000);
+    time = (sync->Cycle / 100);
     if (time > 0) {
-        ticks = COTmrGetTicks(&node->Tmr, time, CO_TMR_UNIT_1MS);
+        ticks = COTmrGetTicks(&node->Tmr, time, CO_TMR_UNIT_100US);
         sync->Tmr = COTmrCreate(&node->Tmr,
             ticks,
             ticks,


### PR DESCRIPTION
# Motivation
For my masters thesis project, i selected this library as a best candidate, deciding by code clarity, use of static allocation, API simplicity and documentation. Unfortunately it only supports slave functionality while for my project it is required that CANOpen stack used supports **SYNC producer** and **SDO client** (i work on ECU handling three CANOpen motor controllers using torque vectoring, for experimental student e-car). Because i know `canopen-stack` API and configuration well, i have decided to extend current functionality with the required one. First step is to implement SYNC producer.

# Definition of done
- [x] periodic SYNC frame transmission based on 1005h and 1006h entry values `[CiA 301]`
- [x] 1005h entry value update allowing activation and deactivation of sync producer `[CiA 301]`
- [x] 1006h entry value update should change SYNC frame transmission cycle time `[CiA 301]`

# Testing of implementation
All tests of new feature have been carried out on STM32H723 nucleo evaluation board using initial configuration: 

```c
    {CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__RW), CO_TSYNCID,     (uintptr_t)0x40000080},
    {CO_KEY(0x1006, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0,              (uintptr_t)20000},
```
and during runtime using following sequence:
```c
    /* Different COB-ID when SYNC producer is active    -> ERROR   */
    CODictWrLong(&CoNode.Dict, CO_DEV(0x1005, 0), 0x40000081);

    vTaskDelay((500 / portTICK_RATE_MS));

    /* Same COB-ID but deactivate SYNC producer         -> SUCCESS */
    CODictWrLong(&CoNode.Dict, CO_DEV(0x1005, 0), 0x00000080);

    vTaskDelay((500 / portTICK_RATE_MS));

    /* Different COB-ID while SYNC producer is inactive -> SUCCESS */
    CODictWrLong(&CoNode.Dict, CO_DEV(0x1005, 0), 0x00000081);

    vTaskDelay((500 / portTICK_RATE_MS));

    /* Different COB-ID and SYNC producer activation    -> SUCCESS */
    CODictWrLong(&CoNode.Dict, CO_DEV(0x1005, 0), 0x40000080);
```
# Conclussion
As i will be using one-time set static configuration in object dictionary most of the time, it is not required to implement full functionality for me. But i though that maybe someone could run into same problem and profit from my contribution, so i am sharing this with you. Please provide me some feedback, thanks in advance.