### PR TITLE
simple handling of 16bit microcontrollers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The CANopen dictionary is an array of object entries, which we can allocate stat
 ```c
 const CO_OBJ MyDict[MY_DICT_LEN] = {
     /* setup application specific dictionary, example entry: */
-    { CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)(0u) },
+    { CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)(0u) },
     /* : */
 };
 ```

--- a/canopen/include/co_obj.h
+++ b/canopen/include/co_obj.h
@@ -86,7 +86,7 @@ extern "C" {
 *    This define may be used in object dictionary definitions. It marks the
 *    first unused object entry.
 */
-#define CO_OBJ_DIR_ENDMARK   { (uint32_t)0, (CO_OBJ_TYPE *)0, (uintptr_t)0 }
+#define CO_OBJ_DIR_ENDMARK   { (uint32_t)0, (CO_OBJ_TYPE *)0, (CO_DATA)0 }
 
 #define CO_TSTRING    ((CO_OBJ_TYPE *)&COTString)   /*!< Object Type String  */
 #define CO_TDOMAIN    ((CO_OBJ_TYPE *)&COTDomain)   /*!< Object Type Domain  */
@@ -262,13 +262,13 @@ extern "C" {
 *    the CAN-ID (standard or extended format)
 * \{
 */
-#define CO_COBID_SYNC_STD(generate, id)      \
-    (((uint32_t)(id) & 0x7ffuL)            | \
+#define CO_COBID_SYNC_STD(generate, id)         \
+    (CO_DATA)(((uint32_t)(id) & 0x7ffuL)      | \
      ((uint32_t)(generate) & 0x1uL) << 30u)
 
-#define CO_COBID_SYNC_EXT(generate, id)      \
-    (((uint32_t)(id) & 0x1fffffffuL)       | \
-     ((uint32_t)0x1uL << 29u)              | \
+#define CO_COBID_SYNC_EXT(generate, id)         \
+    (CO_DATA)(((uint32_t)(id) & 0x1fffffffuL) | \
+     ((uint32_t)0x1uL << 29u)                 | \
      ((uint32_t)(generate) & 0x1uL) << 30u)
 /*! \} */
 
@@ -293,15 +293,15 @@ extern "C" {
 * \{
 */
 #define CO_COBID_TIME_STD(consume, produce, id)    \
-    (((uint32_t)(id) & 0x7ffuL)                  | \
-     ((uint32_t)(consume) & 0x1uL) << 31u)       | \
-     ((uint32_t)(produce) & 0x1uL) << 30u))
+    (CO_DATA)(((uint32_t)(id) & 0x7ffuL)          | \
+     (((uint32_t)(consume) & 0x1uL) << 31u)       | \
+     (((uint32_t)(produce) & 0x1uL) << 30u))
 
 #define CO_COBID_TIME_EXT(consume, produce, id)    \
-    (((uint32_t)(id) & 0x1fffffffuL)             | \
+    (CO_DATA)(((uint32_t)(id) & 0x1fffffffuL)    | \
      ((uint32_t)0x1uL << 29u)                    | \
-     ((uint32_t)(consume) & 0x1uL) << 31u)       | \
-     ((uint32_t)(produce) & 0x1uL) << 30u))
+     (((uint32_t)(consume) & 0x1uL) << 31u)      | \
+     (((uint32_t)(produce) & 0x1uL) << 30u))
 /*! \} */
 
 /*! \brief COB-ID EMCY
@@ -324,13 +324,13 @@ extern "C" {
 * \{
 */
 #define CO_COBID_EMCY_STD(valid, id)               \
-    (((uint32_t)(id) & 0x7ffuL)                  | \
-     ((uint32_t)(1u - ((valid) & 0x1u)) << 31u)
+    (CO_DATA)(((uint32_t)(id) & 0x7ffuL)         | \
+     ((uint32_t)(1u - ((valid) & 0x1u)) << 31u))
 
 #define CO_COBID_EMCY_EXT(valid, id)               \
-    (((uint32_t)(id) & 0x1fffffffuL)             | \
+    (CO_DATA)(((uint32_t)(id) & 0x1fffffffuL)    | \
      ((uint32_t)0x1uL << 29u)                    | \
-     ((uint32_t)(1u - ((valid) & 0x1u)) << 31u)
+     ((uint32_t)(1u - ((valid) & 0x1u)) << 31u))
 /*! \} */
 
 /*! \brief SDO server/client COB-ID parameter
@@ -357,12 +357,12 @@ extern "C" {
 * \{
 */
 #define CO_COBID_SDO_STD(valid, dynamic, id)       \
-    (((uint32_t)(id) & 0x7ffuL)                  | \
+    (CO_DATA)(((uint32_t)(id) & 0x7ffuL)         | \
      (((uint32_t)(dynamic) & 0x1u) << 30u)       | \
      ((uint32_t)(1uL - ((valid) & 0x1u)) << 31u))
 
 #define CO_COBID_SDO_EXT(valid, dynamic, id)       \
-    (((uint32_t)(id) & 0x1fffffffuL)             | \
+    (CO_DATA)(((uint32_t)(id) & 0x1fffffffuL)    | \
      ((uint32_t)0x1u << 29u)                     | \
      (((uint32_t)(dynamic) & 0x1u) << 30u)       | \
      ((uint32_t)(1uL - ((valid) & 0x1u)) << 31u))
@@ -396,11 +396,11 @@ extern "C" {
 * \{
 */
 #define CO_COBID_RPDO_STD(valid, id)               \
-    (((uint32_t)(id) & 0x7ffuL)                  | \
+    (CO_DATA)(((uint32_t)(id) & 0x7ffuL)         | \
      ((uint32_t)(1uL - ((valid) & 0x1u)) << 31u))
 
 #define CO_COBID_RPDO_EXT(valid, id)               \
-    (((uint32_t)(id) & 0x1fffffffuL)             | \
+    (CO_DATA)(((uint32_t)(id) & 0x1fffffffuL)    | \
      ((uint32_t)0x1u << 29u)                     | \
      ((uint32_t)(1uL - ((valid) & 0x1u)) << 31u))
 /*! \} */
@@ -440,12 +440,12 @@ extern "C" {
 * \{
 */
 #define CO_COBID_TPDO_STD(valid, id)             \
-    (((uint32_t)(id) & 0x7ffuL)                | \
+    (CO_DATA)(((uint32_t)(id) & 0x7ffuL)       | \
      ((uint32_t)0x1u << 30u)                   | \
      ((uint32_t)(1uL - ((valid) & 0x1u)) << 31u))
 
 #define CO_COBID_TPDO_EXT(valid, id)             \
-    (((uint32_t)(id) & 0x1fffffffuL)           | \
+    (CO_DATA)(((uint32_t)(id) & 0x1fffffffuL)  | \
      ((uint32_t)0x1u << 29u)                   | \
      ((uint32_t)0x1u << 30u)                   | \
      ((uint32_t)(1uL - ((valid) & 0x1u)) << 31u))
@@ -473,6 +473,21 @@ struct CO_NODE_T;              /* Declaration of canopen node structure      */
 struct CO_OBJ_TYPE_T;          /* Declaration of object type structure       */
 struct CO_DICT_T;              /* Declaration of object dictionary structure */
 
+/*! \brief OBJECT DATA TYPE
+*
+*    This type holds a pointer to the object entrys data. To allow storage of
+*    constant values directly within the object dictionary, this type must be
+*    able to hold a complete 32bit value.
+*
+* \note  This is required for 8bit and 16bit controllers, where pointers may
+*        represent 24bit only.
+*/
+#if UINTPTR_MAX < UINT32_MAX
+typedef uint32_t CO_DATA;
+#else
+typedef uintptr_t CO_DATA;
+#endif
+
 /*! \brief OBJECT ENTRY
 *
 *    This structure holds all data, needed for managing a single object
@@ -490,7 +505,7 @@ typedef struct CO_OBJ_T {
                                        /*   - 7: 1=direct (ptr is value if Type=0) */
     const struct CO_OBJ_TYPE_T *Type;  /*!< ==0: value access via Data-Ptr,        */
                                        /*   !=0: access via type structure         */
-    uintptr_t                   Data;  /*!< Address of value or data structure     */
+    CO_DATA                     Data;  /*!< Address of value or data structure     */
                                        /*   or data value for direct access        */
 } CO_OBJ;
 

--- a/example/dynamic-od/app/app_dict.c
+++ b/example/dynamic-od/app/app_dict.c
@@ -24,7 +24,7 @@
 * PRIVATE FUNCTIONS
 ******************************************************************************/
 
-static void ObjSet(CO_OBJ *obj, uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data)
+static void ObjSet(CO_OBJ *obj, uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data)
 {
     obj->Key  = key;
     obj->Type = type;
@@ -84,7 +84,7 @@ void ODInit (OD_DYN *self, CO_OBJ *root, uint32_t length)
     self->Used   = 0;
 }
 
-void ODAddUpdate(OD_DYN *self, uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data)
+void ODAddUpdate(OD_DYN *self, uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data)
 {
     CO_OBJ  temp;
     CO_OBJ *od;

--- a/example/dynamic-od/app/app_dict.h
+++ b/example/dynamic-od/app/app_dict.h
@@ -42,7 +42,7 @@ typedef struct {
 ******************************************************************************/
 
 void ODInit(OD_DYN *self, CO_OBJ *root, uint32_t length);
-void ODAddUpdate(OD_DYN *self, uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data);
+void ODAddUpdate(OD_DYN *self, uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data);
 void ODSetSpec(OD_DYN *self, CO_NODE_SPEC *spec);
 
 #ifdef __cplusplus               /* for compatibility with C++ environments  */

--- a/example/dynamic-od/app/clock_spec.c
+++ b/example/dynamic-od/app/clock_spec.c
@@ -114,27 +114,27 @@ static void ODCreateSDOServer(OD_DYN *self, uint8_t srv, uint32_t request, uint3
         request  = (uint32_t)0x600;
         response = (uint32_t)0x580;
     }
-    ODAddUpdate(self, CO_KEY(0x1200+srv, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0x02);
-    ODAddUpdate(self, CO_KEY(0x1200+srv, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (uintptr_t)request);
-    ODAddUpdate(self, CO_KEY(0x1200+srv, 2, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (uintptr_t)response);
+    ODAddUpdate(self, CO_KEY(0x1200+srv, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0x02);
+    ODAddUpdate(self, CO_KEY(0x1200+srv, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (CO_DATA)request);
+    ODAddUpdate(self, CO_KEY(0x1200+srv, 2, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (CO_DATA)response);
 }
 
 static void ODCreateTPDOCom(OD_DYN *self, uint8_t num, uint32_t id, uint8_t type, uint16_t inhibit, uint16_t evtimer)
 {
-    ODAddUpdate(self, CO_KEY(0x1800+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0x05);
-    ODAddUpdate(self, CO_KEY(0x1800+num, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (uintptr_t)id);
-    ODAddUpdate(self, CO_KEY(0x1800+num, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)type);
-    ODAddUpdate(self, CO_KEY(0x1800+num, 3, CO_UNSIGNED16|CO_OBJ_D__RW), 0, (uintptr_t)inhibit);
-    ODAddUpdate(self, CO_KEY(0x1800+num, 5, CO_UNSIGNED16|CO_OBJ_D__RW), CO_TEVENT, (uintptr_t)evtimer);
+    ODAddUpdate(self, CO_KEY(0x1800+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0x05);
+    ODAddUpdate(self, CO_KEY(0x1800+num, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (CO_DATA)id);
+    ODAddUpdate(self, CO_KEY(0x1800+num, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)type);
+    ODAddUpdate(self, CO_KEY(0x1800+num, 3, CO_UNSIGNED16|CO_OBJ_D__RW), 0, (CO_DATA)inhibit);
+    ODAddUpdate(self, CO_KEY(0x1800+num, 5, CO_UNSIGNED16|CO_OBJ_D__RW), CO_TEVENT, (CO_DATA)evtimer);
 }
 
 static void ODCreateTPdoMap(OD_DYN *self, uint8_t num, uint32_t *map, uint8_t len)
 {
     uint8_t n;
 
-    ODAddUpdate(self, CO_KEY(0x1A00+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)len);
+    ODAddUpdate(self, CO_KEY(0x1A00+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)len);
     for (n = 0; n < len; n++) {
-        ODAddUpdate(self, CO_KEY(0x1A00+num, 1+n, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)map[n]);
+        ODAddUpdate(self, CO_KEY(0x1A00+num, 1+n, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)map[n]);
     }
 }
 
@@ -145,15 +145,15 @@ static void ODCreateDict(OD_DYN *self)
 
     Obj1001_00_08 = 0;
 
-    ODAddUpdate(self, CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x00000000);
-    ODAddUpdate(self, CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&Obj1001_00_08);
-    ODAddUpdate(self, CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x80);
-    ODAddUpdate(self, CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (uintptr_t)0);
-    ODAddUpdate(self, CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)4);
-    ODAddUpdate(self, CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
-    ODAddUpdate(self, CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
-    ODAddUpdate(self, CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
-    ODAddUpdate(self, CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
+    ODAddUpdate(self, CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x00000000);
+    ODAddUpdate(self, CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&Obj1001_00_08);
+    ODAddUpdate(self, CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x80);
+    ODAddUpdate(self, CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (CO_DATA)0);
+    ODAddUpdate(self, CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)4);
+    ODAddUpdate(self, CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
+    ODAddUpdate(self, CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
+    ODAddUpdate(self, CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
+    ODAddUpdate(self, CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
 
     ODCreateSDOServer(self, 0, CO_COBID_SDO_REQUEST(), CO_COBID_SDO_RESPONSE());
 
@@ -164,10 +164,10 @@ static void ODCreateDict(OD_DYN *self)
     map[2] = CO_LINK(0x2100, 3,  8);
     ODCreateTPdoMap(self, 0, map, 3);
 
-    ODAddUpdate(self, CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)3);
-    ODAddUpdate(self, CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_01_20);
-    ODAddUpdate(self, CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_02_08);
-    ODAddUpdate(self, CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (uintptr_t)&Obj2100_03_08);
+    ODAddUpdate(self, CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)3);
+    ODAddUpdate(self, CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_01_20);
+    ODAddUpdate(self, CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_02_08);
+    ODAddUpdate(self, CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (CO_DATA)&Obj2100_03_08);
 }
 
 /******************************************************************************

--- a/example/quickstart/app/clock_spec.c
+++ b/example/quickstart/app/clock_spec.c
@@ -48,34 +48,34 @@ static uint8_t  Obj2100_03_08 = 0;
 
 /* define the static object dictionary */
 static struct CO_OBJ_T ClockOD[APP_OBJ_N] = {
-    {CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-    {CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ____R_), 0, (uintptr_t)&Obj1001_00_08},
-    {CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x80},
-    {CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (uintptr_t)0},
+    {CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+    {CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ____R_), 0, (CO_DATA)&Obj1001_00_08},
+    {CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x80},
+    {CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (CO_DATA)0},
 
-    {CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)4},
-    {CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-    {CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-    {CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-    {CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
+    {CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)4},
+    {CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+    {CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+    {CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+    {CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
 
-    {CO_KEY(0x1200, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)2},
+    {CO_KEY(0x1200, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)2},
     {CO_KEY(0x1200, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, CO_COBID_SDO_REQUEST()},
     {CO_KEY(0x1200, 2, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, CO_COBID_SDO_RESPONSE()},
 
-    {CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)2},
+    {CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)2},
     {CO_KEY(0x1800, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, CO_COBID_TPDO_DEFAULT(0)},
-    {CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)254},
+    {CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)254},
 
-    {CO_KEY(0x1A00, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)3},
+    {CO_KEY(0x1A00, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)3},
     {CO_KEY(0x1A00, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x01, 32)},
     {CO_KEY(0x1A00, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x02,  8)},
     {CO_KEY(0x1A00, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x03,  8)},
 
-    {CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)3},
-    {CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_01_20},
-    {CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_02_08},
-    {CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (uintptr_t)&Obj2100_03_08},
+    {CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)3},
+    {CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_01_20},
+    {CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_02_08},
+    {CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (CO_DATA)&Obj2100_03_08},
 
     CO_OBJ_DIR_ENDMARK  /* mark end of used objects */
 };

--- a/testsuite/app/app_dict.c
+++ b/testsuite/app/app_dict.c
@@ -28,7 +28,7 @@
 #define OD_SET(obj,key,type,data)   do {     \
         (obj)->Key  = (uint32_t)(key);       \
         (obj)->Type = (CO_OBJ_TYPE *)(type); \
-        (obj)->Data = (uintptr_t)(data);     \
+        (obj)->Data = (CO_DATA)(data);       \
     } while (0)
 
 /* copy content of source object (src) into the destination object (dst) */
@@ -86,7 +86,7 @@ void ODInit(OD_DYN *self, CO_OBJ *root, uint32_t len)
 *          is found in the list, we modify the content of this entry.
 */
 /*---------------------------------------------------------------------------*/
-void ODAdd(OD_DYN *self, uint32_t key, CO_OBJ_TYPE *type, uintptr_t data)
+void ODAdd(OD_DYN *self, uint32_t key, CO_OBJ_TYPE *type, CO_DATA data)
 {
     CO_OBJ  temp;
     CO_OBJ *od;

--- a/testsuite/app/app_dict.h
+++ b/testsuite/app/app_dict.h
@@ -81,7 +81,7 @@ void ODInit(OD_DYN *self, CO_OBJ *root, uint32_t len);
 * \note    You should generate the key with the macro CO_KEY()
 */
 /*---------------------------------------------------------------------------*/
-void ODAdd(OD_DYN *self, uint32_t key, CO_OBJ_TYPE *type, uintptr_t data);
+void ODAdd(OD_DYN *self, uint32_t key, CO_OBJ_TYPE *type, CO_DATA data);
 
 /*---------------------------------------------------------------------------*/
 /*! \brief GET DYNAMIC OBJECT DICTIONARY

--- a/testsuite/app/app_dom.c
+++ b/testsuite/app/app_dom.c
@@ -79,7 +79,7 @@ CO_OBJ_DOM *DomCreate(uint16_t idx, uint8_t sub, uint8_t access, uint32_t size)
 
     DomClear(&Domain[DomIdx]);
     TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|access), CO_TDOMAIN,
-             (uintptr_t)&Domain[DomIdx]);
+             (CO_DATA)&Domain[DomIdx]);
     result = &Domain[DomIdx];
     DomIdx++;
 

--- a/testsuite/app/app_env.c
+++ b/testsuite/app/app_env.c
@@ -224,7 +224,7 @@ void TS_CreateNodeAutoStart(CO_NODE *node)
 *          which is referenced in the specification, too.
 */
 /*---------------------------------------------------------------------------*/
-void TS_ODAdd(uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data)
+void TS_ODAdd(uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data)
 {
     ODAdd(&TS_ODDyn, key, (CO_OBJ_TYPE *)type, data);
 }

--- a/testsuite/app/app_env.h
+++ b/testsuite/app/app_env.h
@@ -490,7 +490,7 @@ void TS_CreateNodeAutoStart(CO_NODE *node);
 *          object entry data according to user manual
 */
 /*---------------------------------------------------------------------------*/
-void TS_ODAdd(uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data);
+void TS_ODAdd(uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data);
 
 /*---------------------------------------------------------------------------*/
 /*! \brief SETUP THE MANDATORY OBJECT ENTRIES OF AN OBJECT DICTIONARY

--- a/testsuite/app/app_stdobj.h
+++ b/testsuite/app/app_stdobj.h
@@ -41,7 +41,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1000_0(val)                             \
     CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1001h:0 - ERROR REGISTER
@@ -52,7 +52,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1001_0(ref)                             \
     CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ___PR_), \
-    0, (uintptr_t)(ref)
+    0, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1002h:0 - MANUFACTURER STATUS REGISTER
@@ -63,7 +63,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1002_0(ref)                             \
     CO_KEY(0x1002, 0, CO_UNSIGNED32|CO_OBJ___PR_), \
-    0, (uintptr_t)(ref)
+    0, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1003h:0 - NUMBER OF ERRORS
@@ -74,7 +74,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1003_0(ref)                            \
     CO_KEY(0x1003, 0, CO_UNSIGNED8|CO_OBJ____RW), \
-    CO_TEMCY, (uintptr_t)(ref)
+    CO_TEMCY, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1003h:n - STANDARD ERROR FIELD
@@ -89,7 +89,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1003_X(sub,ref)                             \
     CO_KEY(0x1003, (sub), CO_UNSIGNED32|CO_OBJ____R_), \
-    CO_TEMCY, (uintptr_t)(ref)
+    CO_TEMCY, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1005h:0 - COB-ID SYNC MESSAGE
@@ -100,7 +100,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1005_0(val)                             \
     CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ____RW), \
-    CO_TSYNCID, (uintptr_t)(val)
+    CO_TSYNCID, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1006h:0 - COMMUNICATION CYCLE PERIOD
@@ -111,7 +111,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1006_0(val)                             \
     CO_KEY(0x1006, 0, CO_UNSIGNED32|CO_OBJ____RW), \
-    CO_TSYNCCYCLE, (uintptr_t)(val)
+    CO_TSYNCCYCLE, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1014h:0 - COB-ID EMCY MESSAGE
@@ -124,7 +124,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1014_0(ref)                             \
     CO_KEY(0x1014, 0, CO_UNSIGNED32|CO_OBJ__N_RW), \
-    CO_TEMCYID, (uintptr_t)(ref)
+    CO_TEMCYID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1017h:0 - PRODUCER HEARTBEAT TIME
@@ -135,7 +135,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1017_0(ref)                             \
     CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), \
-    CO_THB_PROD, (uintptr_t)(ref)
+    CO_THB_PROD, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1018h:0 - IDENTITY OBJECT
@@ -146,7 +146,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1018_0(val)                            \
     CO_KEY(0x1018, 0, CO_UNSIGNED8|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1018h:1 - IDENTITY OBJECT VENDOR-ID
@@ -157,7 +157,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1018_1(val)                             \
     CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1018h:2 - IDENTITY OBJECT PRODUCT CODE
@@ -168,7 +168,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1018_2(val)                             \
     CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1018h:3 - IDENTITY OBJECT REVISION NUMBER
@@ -179,7 +179,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1018_3(val)                             \
     CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1018h:3 - IDENTITY OBJECT SERIAL NUMBER
@@ -190,7 +190,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1018_4(val)                             \
     CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1200h:0 - SDO SERVER PARAMETER
@@ -204,7 +204,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ120X_0(srv,val)                                \
     CO_KEY(0x1200 + (srv), 0, CO_UNSIGNED8|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1200h:1 - SDO SERVER PARAMETER COB-ID CLIENT TO SERVER (RX)
@@ -220,7 +220,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ120X_1(srv,ref)                                 \
     CO_KEY(0x1200 + (srv), 1, CO_UNSIGNED32|CO_OBJ__N_RW), \
-    CO_TSDOID, (uintptr_t)(ref)
+    CO_TSDOID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1200h:2 - SDO SERVER PARAMETER COB-ID SERVER TO CLIENT (TX)
@@ -236,7 +236,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ120X_2(srv,ref)                                 \
     CO_KEY(0x1200 + (srv), 2, CO_UNSIGNED32|CO_OBJ__N_RW), \
-    CO_TSDOID, (uintptr_t)(ref)
+    CO_TSDOID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1280h:0 - SDO CLIENT PARAMETER
@@ -250,7 +250,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ128X_0(cli,val)                                \
     CO_KEY(0x1200 + (cli), 0, CO_UNSIGNED8|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1280h:1 - SDO CLIENT PARAMETER COB-ID CLIENT TO SERVER (TX)
@@ -266,7 +266,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ128X_1(cli,ref)                                 \
     CO_KEY(0x1280 + (cli), 1, CO_UNSIGNED32|CO_OBJ____RW), \
-    CO_TSDOID, (uintptr_t)(ref)
+    CO_TSDOID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1280h:2 - SDO CLIENT PARAMETER COB-ID SERVER TO CLIENT (RX)
@@ -282,7 +282,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ128X_2(cli,ref)                                 \
     CO_KEY(0x1280 + (cli), 2, CO_UNSIGNED32|CO_OBJ____RW), \
-    CO_TSDOID, (uintptr_t)(ref)
+    CO_TSDOID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1280h:3 - SDO CLIENT PARAMETER NODE-ID OF THE SDO SERVER
@@ -296,7 +296,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ128X_3(cli,ref)                                 \
     CO_KEY(0x1280 + (cli), 3, CO_UNSIGNED8|CO_OBJ____RW), \
-    0, (uintptr_t)(ref)
+    0, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 14XXh:0 - RPDO COMMUNICATION PARAMETER
@@ -310,7 +310,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ14XX_0(num,val)                                \
     CO_KEY(0x1400 + (num), 0, CO_UNSIGNED8|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 14XXh:1 - RPDO COMMUNICATION PARAMETER COB-ID USED BY RPDO
@@ -326,7 +326,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ14XX_1(num,ref)                                 \
     CO_KEY(0x1400 + (num), 1, CO_UNSIGNED32|CO_OBJ__N_RW), \
-    CO_TPDOID, (uintptr_t)(ref)
+    CO_TPDOID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 14XXh:2 - RPDO COMMUNICATION PARAMETER TRANSMISSION TYPE
@@ -340,7 +340,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ14XX_2(num,ref)                                \
     CO_KEY(0x1400 + (num), 2, CO_UNSIGNED8|CO_OBJ____RW), \
-    CO_TPDOTYPE, (uintptr_t)(ref)
+    CO_TPDOTYPE, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 16XXh:0 - RPDO MAPPING PARAMETER
@@ -355,7 +355,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ16XX_0(num,ref)                                \
     CO_KEY(0x1600 + (num), 0, CO_UNSIGNED8|CO_OBJ____RW), \
-    CO_TPDONUM, (uintptr_t)(ref)
+    CO_TPDONUM, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 16XXh:N - RPDO MAPPING PARAMETER APPLICATION OBJECT #N
@@ -373,7 +373,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ16XX_N(num,map,ref)                                 \
     CO_KEY(0x1600 + (num), (map), CO_UNSIGNED32|CO_OBJ____RW), \
-    CO_TPDOMAP, (uintptr_t)(ref)
+    CO_TPDOMAP, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 18XXh:0 - TPDO COMMUNICATION PARAMETER
@@ -387,7 +387,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ18XX_0(num,val)                                \
     CO_KEY(0x1800 + (num), 0, CO_UNSIGNED8|CO_OBJ_D__R_), \
-    0, (uintptr_t)(val)
+    0, (CO_DATA)(val)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 18XXh:1 - TPDO COMMUNICATION PARAMETER COB-ID USED BY TPDO
@@ -403,7 +403,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ18XX_1(num,ref)                                 \
     CO_KEY(0x1800 + (num), 1, CO_UNSIGNED32|CO_OBJ__N_RW), \
-    CO_TPDOID, (uintptr_t)(ref)
+    CO_TPDOID, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 18XXh:2 - TPDO COMMUNICATION PARAMETER TRANSMISSION TYPE
@@ -417,7 +417,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ18XX_2(num,ref)                                \
     CO_KEY(0x1800 + (num), 2, CO_UNSIGNED8|CO_OBJ____RW), \
-    CO_TPDOTYPE, (uintptr_t)(ref)
+    CO_TPDOTYPE, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 18XXh:3 - TPDO COMMUNICATION PARAMETER INHIBIT TIME
@@ -431,7 +431,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ18XX_3(num,ref)                                 \
     CO_KEY(0x1800 + (num), 3, CO_UNSIGNED16|CO_OBJ____RW), \
-    0, (uintptr_t)(ref)
+    0, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 18XXh:5 - TPDO COMMUNICATION PARAMETER EVENT TIMER
@@ -445,7 +445,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ18XX_5(num,ref)                                 \
     CO_KEY(0x1800 + (num), 5, CO_UNSIGNED16|CO_OBJ____RW), \
-    CO_TEVENT, (uintptr_t)(ref)
+    CO_TEVENT, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1AXXh:0 - TPDO MAPPING PARAMETER
@@ -460,7 +460,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1AXX_0(num,ref)                                \
     CO_KEY(0x1A00 + (num), 0, CO_UNSIGNED8|CO_OBJ____RW), \
-    CO_TPDONUM, (uintptr_t)(ref)
+    CO_TPDONUM, (CO_DATA)(ref)
 
 /*---------------------------------------------------------------------------*/
 /*! \brief OBJECT 1AXXh:N - TPDO MAPPING PARAMETER APPLICATION OBJECT #N
@@ -478,7 +478,7 @@ extern "C" {
 /*---------------------------------------------------------------------------*/
 #define OBJ1AXX_N(num,map,ref)                                 \
     CO_KEY(0x1A00 + (num), (map), CO_UNSIGNED32|CO_OBJ____RW), \
-    CO_TPDOMAP, (uintptr_t)(ref)
+    CO_TPDOMAP, (CO_DATA)(ref)
 
 
 #ifdef __cplusplus               /* for compatibility with C++ environments  */

--- a/testsuite/tests/nmt_hbc.c
+++ b/testsuite/tests/nmt_hbc.c
@@ -40,8 +40,8 @@ TS_DEF_MAIN(TS_HBCons_RdEntry)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     CODictRdLong(&node.Dict, CO_DEV(0x1016, 1), &value);
@@ -69,8 +69,8 @@ TS_DEF_MAIN(TS_HBCons_WaitForHb)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_Wait(&node, 200);
@@ -100,8 +100,8 @@ TS_DEF_MAIN(TS_HBCons_CheckState)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -131,8 +131,8 @@ TS_DEF_MAIN(TS_HBCons_SingleEvent)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -163,8 +163,8 @@ TS_DEF_MAIN(TS_HBCons_MultiEvent)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -195,8 +195,8 @@ TS_DEF_MAIN(TS_HBCons_NoEvent)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -228,8 +228,8 @@ TS_DEF_MAIN(TS_HBCons_Jitter)
     data.Time   = 60;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -265,8 +265,8 @@ TS_DEF_MAIN(TS_HBCons_MasterId)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(0, 5);
@@ -326,8 +326,8 @@ TS_DEF_MAIN(TS_HBCons_OtherConsumer)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -365,9 +365,9 @@ TS_DEF_MAIN(TS_HBCons_MultiConsumer)
     data2.Time   = 70;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)2);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data1);
-    TS_ODAdd(CO_KEY(0x1016, 2, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (uintptr_t)&data2);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)2);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data1);
+    TS_ODAdd(CO_KEY(0x1016, 2, CO_UNSIGNED32|CO_OBJ____R_), CO_THB_CONS, (CO_DATA)&data2);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -403,8 +403,8 @@ TS_DEF_MAIN(TS_HBCons_WrEntry)
     uint32_t     value = 0x000A0032;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     CODictWrLong(&node.Dict, CO_DEV(0x1016, 1), value);
@@ -431,8 +431,8 @@ TS_DEF_MAIN(TS_HBCons_DynEvent)
     int16_t     events;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     CODictWrLong(&node.Dict, CO_DEV(0x1016, 1), value);
@@ -463,8 +463,8 @@ TS_DEF_MAIN(TS_HBCons_DynSdoError)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);
@@ -500,8 +500,8 @@ TS_DEF_MAIN(TS_HBCons_DynSdoDisable)
     data.Time   = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (uintptr_t)1);
-    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x1016, 0, CO_UNSIGNED8|CO_OBJ_D__R_), 0, (CO_DATA)1);
+    TS_ODAdd(CO_KEY(0x1016, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_THB_CONS, (CO_DATA)&data);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_HB_SEND(10, 5);

--- a/testsuite/tests/nmt_hbp.c
+++ b/testsuite/tests/nmt_hbp.c
@@ -38,7 +38,7 @@ TS_DEF_MAIN(TS_HBProd_Disable)
     uint16_t     time = 0;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), CO_THB_PROD, (uintptr_t)&time);
+    TS_ODAdd(CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), CO_THB_PROD, (CO_DATA)&time);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_Wait(&node, 1000);                             /* wait 1000ms                              */
@@ -61,7 +61,7 @@ TS_DEF_MAIN(TS_HBProd_PreOperational)
     uint16_t     time = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), CO_THB_PROD, (uintptr_t)&time);
+    TS_ODAdd(CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), CO_THB_PROD, (CO_DATA)&time);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_Wait(&node, 50);                               /* wait heartbeat time                      */
@@ -86,7 +86,7 @@ TS_DEF_MAIN(TS_HBProd_Operational)
     uint16_t     time = 50;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), CO_THB_PROD, (uintptr_t)&time);
+    TS_ODAdd(CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), CO_THB_PROD, (CO_DATA)&time);
     TS_CreateNode(&node,0);
                                                       /*------------------------------------------*/
     TS_NMT_SEND(0x01, 1);                            /* set node-id 0x01 to operational          */

--- a/testsuite/tests/nmt_lss.c
+++ b/testsuite/tests/nmt_lss.c
@@ -97,10 +97,10 @@ TS_DEF_MAIN(TS_Lss_SelIdent_WrongVendor)
 
     /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&vendor);
-    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&product);
-    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&revision);
-    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&serial);
+    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&vendor);
+    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&product);
+    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&revision);
+    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&serial);
     TS_CreateNode(&node,0);
     /*------------------------------------------*/
 
@@ -131,10 +131,10 @@ TS_DEF_MAIN(TS_Lss_SelIdent_WrongProduct)
 
     /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&vendor);
-    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&product);
-    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&revision);
-    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&serial);
+    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&vendor);
+    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&product);
+    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&revision);
+    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&serial);
     TS_CreateNode(&node,0);
     /*------------------------------------------*/
 
@@ -165,10 +165,10 @@ TS_DEF_MAIN(TS_Lss_SelIdent_WrongRevision)
 
     /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&vendor);
-    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&product);
-    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&revision);
-    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&serial);
+    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&vendor);
+    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&product);
+    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&revision);
+    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&serial);
     TS_CreateNode(&node,0);
     /*------------------------------------------*/
 
@@ -199,10 +199,10 @@ TS_DEF_MAIN(TS_Lss_SelIdent_WrongSerial)
 
     /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&vendor);
-    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&product);
-    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&revision);
-    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&serial);
+    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&vendor);
+    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&product);
+    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&revision);
+    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&serial);
     TS_CreateNode(&node,0);
     /*------------------------------------------*/
 
@@ -232,10 +232,10 @@ TS_DEF_MAIN(TS_Lss_SelIdent_Ok)
 
     /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&vendor);
-    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&product);
-    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&revision);
-    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (uintptr_t)&serial);
+    TS_ODAdd(CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&vendor);
+    TS_ODAdd(CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&product);
+    TS_ODAdd(CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&revision);
+    TS_ODAdd(CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ____R_), 0, (CO_DATA)&serial);
     TS_CreateNode(&node,0);
     /*------------------------------------------*/
 

--- a/testsuite/tests/pdo_dyn.c
+++ b/testsuite/tests/pdo_dyn.c
@@ -476,7 +476,7 @@ TS_DEF_MAIN(TS_RPdo_BadIdSubIdxCfg)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &pdo_id, &pdo_type);
     TS_CreateRPdoMap(0, 0, &pdo_len);
-    TS_ODAdd(CO_KEY(0x1400, 3, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (uintptr_t)&pdo_id);
+    TS_ODAdd(CO_KEY(0x1400, 3, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (CO_DATA)&pdo_id);
     TS_CreateNode(&node,0);
 
     /* no PDO COB-ID sub-index */
@@ -498,7 +498,7 @@ TS_DEF_MAIN(TS_TPdo_BadIdSubIdxCfg)
 
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &pdo_id, &pdo_type, &pdo_inhibit, &pdo_evtimer);
-    TS_ODAdd(CO_KEY(0x1800, 6, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (uintptr_t)&pdo_id);
+    TS_ODAdd(CO_KEY(0x1800, 6, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (CO_DATA)&pdo_id);
     TS_CreateTPdoMap(0, 0, &pdo_len);
     TS_CreateNode(&node,0);
 
@@ -526,7 +526,7 @@ TS_DEF_MAIN(TS_RPdo_BadIdIdxCfg)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &pdo_id, &pdo_type);
     TS_CreateRPdoMap(0, 0, &pdo_len);
-    TS_ODAdd(CO_KEY(0x2502, 1, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (uintptr_t)&pdo_id);
+    TS_ODAdd(CO_KEY(0x2502, 1, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (CO_DATA)&pdo_id);
     TS_CreateNode(&node,0);
 
     /* no PDO communication parameter index */
@@ -548,7 +548,7 @@ TS_DEF_MAIN(TS_TPdo_BadIdIdxCfg)
 
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &pdo_id, &pdo_type, &pdo_inhibit, &pdo_evtimer);
-    TS_ODAdd(CO_KEY(0x2501, 1, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (uintptr_t)&pdo_id);
+    TS_ODAdd(CO_KEY(0x2501, 1, CO_UNSIGNED32|CO_OBJ__N_RW), CO_TPDOID, (CO_DATA)&pdo_id);
     TS_CreateTPdoMap(0, 0, &pdo_len);
     TS_CreateNode(&node,0);
 
@@ -580,8 +580,8 @@ TS_DEF_MAIN(TS_RPdo_MapNumChange)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &pdo_id, &pdo_type);
     TS_CreateRPdoMap(0, &pdo_map[0], &pdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 31, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 32, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 31, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 32, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[1]);
     TS_CreateNode(&node,0);
 
     /* PDO valid to invalid */
@@ -631,8 +631,8 @@ TS_DEF_MAIN(TS_RPdo_ChangeActiveMap)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &pdo_id, &pdo_type);
     TS_CreateRPdoMap(0, &pdo_map[0], &pdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 31, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 32, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 31, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 32, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[1]);
     TS_CreateNode(&node,0);
 
     /* set mapping to 0 */
@@ -805,7 +805,7 @@ TS_DEF_MAIN(TS_TPdo_BadMapNumSubIdxCfg)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &pdo_id, &pdo_type, &pdo_inhibit, &pdo_evtimer);
     TS_CreateTPdoMap(0, 0, &pdo_len);
-    TS_ODAdd(CO_KEY(0x1A00, 9, CO_UNSIGNED8 |CO_OBJ____RW), CO_TPDONUM, (uintptr_t)&pdo_len);
+    TS_ODAdd(CO_KEY(0x1A00, 9, CO_UNSIGNED8 |CO_OBJ____RW), CO_TPDONUM, (CO_DATA)&pdo_len);
     TS_CreateNode(&node,0);
 
     /* no PDO mapping number sub-index */
@@ -836,7 +836,7 @@ TS_DEF_MAIN(TS_RPdo_BadMapNumIdxCfg)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &pdo_id, &pdo_type);
     TS_CreateRPdoMap(0, &pdo_map[0], &pdo_len);
-    TS_ODAdd(CO_KEY(0x2503, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TPDONUM, (uintptr_t)&pdo_len);
+    TS_ODAdd(CO_KEY(0x2503, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TPDONUM, (CO_DATA)&pdo_len);
     TS_CreateNode(&node,0);
 
     /* no PDO mapping index */
@@ -861,7 +861,7 @@ TS_DEF_MAIN(TS_TPdo_BadMapNumIdxCfg)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &pdo_id, &pdo_type, &pdo_inhibit, &pdo_evtimer);
     TS_CreateTPdoMap(0, 0, &pdo_len);
-    TS_ODAdd(CO_KEY(0x2504, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TPDONUM, (uintptr_t)&pdo_len);
+    TS_ODAdd(CO_KEY(0x2504, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TPDONUM, (CO_DATA)&pdo_len);
     TS_CreateNode(&node,0);
 
     /* no PDO mapping index */

--- a/testsuite/tests/pdo_rx.c
+++ b/testsuite/tests/pdo_rx.c
@@ -44,14 +44,14 @@ TS_DEF_MAIN(TS_RPdo_8x1Byte)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0C, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[1]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0D, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[2]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0E, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[3]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0F, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[4]);
-    TS_ODAdd(CO_KEY(0x2500, 0x10, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[5]);
-    TS_ODAdd(CO_KEY(0x2500, 0x11, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[6]);
-    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data[7]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0C, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0D, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[2]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0E, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[3]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0F, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[4]);
+    TS_ODAdd(CO_KEY(0x2500, 0x10, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[5]);
+    TS_ODAdd(CO_KEY(0x2500, 0x11, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[6]);
+    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data[7]);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0x51);
@@ -98,10 +98,10 @@ TS_DEF_MAIN(TS_RPdo_4x2Byte)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x16, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&data[1]);
-    TS_ODAdd(CO_KEY(0x2500, 0x17, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&data[2]);
-    TS_ODAdd(CO_KEY(0x2500, 0x18, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&data[3]);
+    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x16, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x17, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&data[2]);
+    TS_ODAdd(CO_KEY(0x2500, 0x18, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&data[3]);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0x41);
@@ -140,8 +140,8 @@ TS_DEF_MAIN(TS_RPdo_2x4Byte)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x20, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x20, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&data[1]);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0x31);
@@ -178,9 +178,9 @@ TS_DEF_MAIN(TS_RPdo_1_2_4Byte)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data8);
-    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&data16);
-    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&data32);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&data16);
+    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&data32);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0x21);
@@ -243,7 +243,7 @@ TS_DEF_MAIN(TS_RPdo_UpdateAfterSync)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,  &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map, &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0x11);
@@ -276,7 +276,7 @@ TS_DEF_MAIN(TS_RPdo_UpdateType254)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,  &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map, &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0x31);
@@ -305,7 +305,7 @@ TS_DEF_MAIN(TS_RPdo_UpdateType255)
     TS_CreateMandatoryDir();
     TS_CreateRPdoCom(0, &rpdo_id,  &rpdo_type);
     TS_CreateRPdoMap(0, &rpdo_map, &rpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (uintptr_t)&data);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ____RW), 0, (CO_DATA)&data);
     TS_CreateNodeAutoStart(&node);
 
     TS_PDO_SEND(0x201, 0xE1);

--- a/testsuite/tests/pdo_tx.c
+++ b/testsuite/tests/pdo_tx.c
@@ -47,14 +47,14 @@ TS_DEF_MAIN(TS_TPdo_8x1Byte)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map[0], &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0C, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[1]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0D, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[2]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0E, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[3]);
-    TS_ODAdd(CO_KEY(0x2500, 0x0F, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[4]);
-    TS_ODAdd(CO_KEY(0x2500, 0x10, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[5]);
-    TS_ODAdd(CO_KEY(0x2500, 0x11, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[6]);
-    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data[7]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0C, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0D, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[2]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0E, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[3]);
+    TS_ODAdd(CO_KEY(0x2500, 0x0F, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[4]);
+    TS_ODAdd(CO_KEY(0x2500, 0x10, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[5]);
+    TS_ODAdd(CO_KEY(0x2500, 0x11, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[6]);
+    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data[7]);
     TS_CreateNodeAutoStart(&node);
 
     TS_SYNC_SEND();
@@ -95,10 +95,10 @@ TS_DEF_MAIN(TS_TPdo_4x2Byte)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map[0], &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x16, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&data[1]);
-    TS_ODAdd(CO_KEY(0x2500, 0x17, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&data[2]);
-    TS_ODAdd(CO_KEY(0x2500, 0x18, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&data[3]);
+    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x16, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x17, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&data[2]);
+    TS_ODAdd(CO_KEY(0x2500, 0x18, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&data[3]);
     TS_CreateNodeAutoStart(&node);
 
     TS_SYNC_SEND();
@@ -135,8 +135,8 @@ TS_DEF_MAIN(TS_TPdo_2x4Byte)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map[0], &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ___PRW), 0, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x20, CO_UNSIGNED32|CO_OBJ___PRW), 0, (uintptr_t)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ___PRW), 0, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x20, CO_UNSIGNED32|CO_OBJ___PRW), 0, (CO_DATA)&data[1]);
     TS_CreateNodeAutoStart(&node);
 
     TS_SYNC_SEND();
@@ -173,9 +173,9 @@ TS_DEF_MAIN(TS_TPdo_1_2_4Byte)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map[0], &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
-    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&data16);
-    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ___PRW), 0, (uintptr_t)&data32);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x15, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&data16);
+    TS_ODAdd(CO_KEY(0x2500, 0x1F, CO_UNSIGNED32|CO_OBJ___PRW), 0, (CO_DATA)&data32);
     TS_CreateNodeAutoStart(&node);
 
     TS_SYNC_SEND();
@@ -241,7 +241,7 @@ TS_DEF_MAIN(TS_TPdo_After3Sync)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     TS_SYNC_SEND();
@@ -284,7 +284,7 @@ TS_DEF_MAIN(TS_TPdo_OnChangeAfterSync)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     TS_SYNC_SEND();
@@ -328,7 +328,7 @@ TS_DEF_MAIN(TS_TPdo_After240Sync)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     for (n=0; n < 239; n++) {
@@ -370,7 +370,7 @@ TS_DEF_MAIN(TS_TPdo_Type254ViaObj)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     for (n = 0; n < 256; n++) {
@@ -414,7 +414,7 @@ TS_DEF_MAIN(TS_TPdo_Type255ViaObj)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     for (n = 0; n < 256; n++) {
@@ -456,7 +456,7 @@ TS_DEF_MAIN(TS_TPdo_Type254ViaNum)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     for (n = 0; n < 256; n++) {
@@ -497,7 +497,7 @@ TS_DEF_MAIN(TS_TPdo_Type255ViaNum)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     for (n = 0; n < 256; n++) {
@@ -536,7 +536,7 @@ TS_DEF_MAIN(TS_TPdo_Tmr)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNode(&node,0);
 
                                                       /* wait more than 1 event timer time        */
@@ -582,7 +582,7 @@ TS_DEF_MAIN(TS_TPdo_TmrAndNum)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     TS_Wait(&node, 200);                              /* wait 200ms                               */
@@ -641,7 +641,7 @@ TS_DEF_MAIN(TS_TPdo_Inhibit)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     TS_Wait(&node, 200);                              /* wait 200ms                               */
@@ -702,7 +702,7 @@ TS_DEF_MAIN(TS_TPdo_TmrAndInhibit)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     TS_Wait(&node, 70);                               /* wait 70ms                                */
@@ -758,7 +758,7 @@ TS_DEF_MAIN(TS_TPdo_ChangeTmr)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNode(&node,0);
 
     TS_SDO_SEND (0x22, 0x1800, 5, 200);
@@ -810,7 +810,7 @@ TS_DEF_MAIN(TS_TPdo_TmrFastest)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNodeAutoStart(&node);
 
     TS_Wait(&node, 210);                              /* wait 210ms                               */
@@ -876,8 +876,8 @@ TS_DEF_MAIN(TS_TPdo_Async)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map[0], &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x29, CO_UNSIGNED32|CO_OBJ___PRW), CO_TASYNC, (uintptr_t)&data[0]);
-    TS_ODAdd(CO_KEY(0x2500, 0x2A, CO_UNSIGNED32|CO_OBJ___PRW),         0, (uintptr_t)&data[1]);
+    TS_ODAdd(CO_KEY(0x2500, 0x29, CO_UNSIGNED32|CO_OBJ___PRW), CO_TASYNC, (CO_DATA)&data[0]);
+    TS_ODAdd(CO_KEY(0x2500, 0x2A, CO_UNSIGNED32|CO_OBJ___PRW),         0, (CO_DATA)&data[1]);
     TS_CreateNodeAutoStart(&node);
 
     CODictWrLong(&node.Dict,CO_DEV(0x2500,0x29),0L);  /* write to asynchronous object entry       */
@@ -914,7 +914,7 @@ TS_DEF_MAIN(TS_TPdo_SwitchToOpWhileInOp)
     TS_CreateMandatoryDir();
     TS_CreateTPdoCom(0, &tpdo_id, &tpdo_type, &tpdo_inhibit, &tpdo_evtime);
     TS_CreateTPdoMap(0, &tpdo_map, &tpdo_len);
-    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (uintptr_t)&data8);
+    TS_ODAdd(CO_KEY(0x2500, 0x0B, CO_UNSIGNED8 |CO_OBJ___PRW), 0, (CO_DATA)&data8);
     TS_CreateNode(&node,0);
 
                                                       /* wait more than 1 event timer time        */

--- a/testsuite/tests/sdos_blk_down.c
+++ b/testsuite/tests/sdos_blk_down.c
@@ -43,7 +43,7 @@ TS_DEF_MAIN(TS_BlkWr_Basic)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT BLOCK DOWNLOAD ================*/
@@ -1054,7 +1054,7 @@ TS_DEF_MAIN(TS_BlkWr_DomainNullPtr)
     uint8_t   sub  = 0;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (uintptr_t)0);
+    TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (CO_DATA)0);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT SEGMENTED DOWNLOAD  ===========*/
@@ -1373,7 +1373,7 @@ TS_DEF_MAIN(TS_BlkWr_ExpWrAfter43ByteDomain)
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
     dom = DomCreate(idx, sub, CO_OBJ____RW, size);
-    TS_ODAdd(CO_KEY(idx2, sub2, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx2, sub2, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT BLOCK DOWNLOAD ================*/

--- a/testsuite/tests/sdos_blk_up.c
+++ b/testsuite/tests/sdos_blk_up.c
@@ -66,7 +66,7 @@ TS_DEF_MAIN(TS_BlkRd_Basic)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
                                                       /*===== INIT BLOCK UPLOAD (PHASE I) ========*/
     TS_SDO_SEND (0xA0, idx, sub, CO_SDO_BUF_SEG);
@@ -878,7 +878,7 @@ TS_DEF_MAIN(TS_BlkRd_DomainNullPtr)
     uint8_t   sub  = 9;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (uintptr_t)0);
+    TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (CO_DATA)0);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT SEGMENTED UPLOAD ==============*/

--- a/testsuite/tests/sdos_exp_down.c
+++ b/testsuite/tests/sdos_exp_down.c
@@ -119,7 +119,7 @@ TS_DEF_MAIN(TS_ExpWr_1BytePara)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -161,7 +161,7 @@ TS_DEF_MAIN(TS_ExpWr_2BytePara)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -203,7 +203,7 @@ TS_DEF_MAIN(TS_ExpWr_4BytePara)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -245,7 +245,7 @@ TS_DEF_MAIN(TS_ExpWr_1ByteVar)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -287,7 +287,7 @@ TS_DEF_MAIN(TS_ExpWr_2ByteVar)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -329,7 +329,7 @@ TS_DEF_MAIN(TS_ExpWr_4ByteVar)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -371,7 +371,7 @@ TS_DEF_MAIN(TS_ExpWr_2ByteVar_NoLen)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -412,7 +412,7 @@ TS_DEF_MAIN(TS_ExpWr_BadCmd)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -452,7 +452,7 @@ TS_DEF_MAIN(TS_ExpWr_ObjNotExist)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -492,7 +492,7 @@ TS_DEF_MAIN(TS_ExpWr_SubIdxNotExist)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -532,7 +532,7 @@ TS_DEF_MAIN(TS_ExpWr_ReadOnly)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____R_), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____R_), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -571,7 +571,7 @@ TS_DEF_MAIN(TS_ExpWr_LenTooHigh)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -610,7 +610,7 @@ TS_DEF_MAIN(TS_ExpWr_LenTooLow)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -649,7 +649,7 @@ TS_DEF_MAIN(TS_ExpWr_DataNullPtr)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)0);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)0);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -688,7 +688,7 @@ TS_DEF_MAIN(TS_ExpWr_UserWriteErr)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), MY_TYPE, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), MY_TYPE, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */

--- a/testsuite/tests/sdos_exp_up.c
+++ b/testsuite/tests/sdos_exp_up.c
@@ -119,7 +119,7 @@ TS_DEF_MAIN(TS_ExpRd_1BytePara)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -164,7 +164,7 @@ TS_DEF_MAIN(TS_ExpRd_2BytePara)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -209,7 +209,7 @@ TS_DEF_MAIN(TS_ExpRd_4BytePara)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -254,7 +254,7 @@ TS_DEF_MAIN(TS_ExpRd_1ByteVar)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -299,7 +299,7 @@ TS_DEF_MAIN(TS_ExpRd_2ByteVar)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -343,7 +343,7 @@ TS_DEF_MAIN(TS_ExpRd_4ByteVar)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ___PRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ___PRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -387,7 +387,7 @@ TS_DEF_MAIN(TS_ExpRd_4ByteConst)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x44434241);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x44434241);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -432,7 +432,7 @@ TS_DEF_MAIN(TS_ExpRd_4ByteConstNodeId)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32 | CO_OBJ_DN_R_), 0, (uintptr_t)0x44434241);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32 | CO_OBJ_DN_R_), 0, (CO_DATA)0x44434241);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -478,7 +478,7 @@ TS_DEF_MAIN(TS_ExpRd_2ByteParaNodeId)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ__NPRW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ__NPRW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -523,7 +523,7 @@ TS_DEF_MAIN(TS_ExpRd_BadCmd)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -612,7 +612,7 @@ TS_DEF_MAIN(TS_ExpRd_SubIdxNotExist)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -658,7 +658,7 @@ TS_DEF_MAIN(TS_ExpRd_WriteOnly)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ_____W), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ_____W), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -703,7 +703,7 @@ TS_DEF_MAIN(TS_ExpRd_DataNullPtr)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)0);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)0);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */
@@ -748,7 +748,7 @@ TS_DEF_MAIN(TS_ExpRd_UserReadErr)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), MY_TYPE, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), MY_TYPE, (CO_DATA)&val);
     TS_CreateNode(&node,0);
 
     /* -- TEST -- */

--- a/testsuite/tests/sdos_seg_down.c
+++ b/testsuite/tests/sdos_seg_down.c
@@ -43,7 +43,7 @@ TS_DEF_MAIN(TS_SegWr_Basic)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
                                                       /*===== INIT SEGMENTED DOWNLOAD  ===========*/
     TS_SDO_SEND (0x21, idx, sub, 4);
@@ -81,7 +81,7 @@ TS_DEF_MAIN(TS_SegWr_Basic_Bad)
 
     /* -- PREPARATION -- */
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&val);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&val);
     TS_CreateNode(&node,0);
                                                       /*===== INIT SEGMENTED DOWNLOAD  ===========*/
     TS_SDO_SEND (0x21, idx, sub, 4);
@@ -581,7 +581,7 @@ TS_DEF_MAIN(TS_SegWr_DomainNullPtr)
     uint8_t  sub  = 0;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (uintptr_t)0);
+    TS_ODAdd(CO_KEY(idx, sub, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (CO_DATA)0);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT SEGMENTED DOWNLOAD  ===========*/

--- a/testsuite/tests/sdos_seg_up.c
+++ b/testsuite/tests/sdos_seg_up.c
@@ -257,7 +257,7 @@ TS_DEF_MAIN(TS_SegRd_23ByteString)
     Str23.Start  = (uint8_t *)strPtr;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_STRING|CO_OBJ____R_), CO_TSTRING, (uintptr_t)&Str23);
+    TS_ODAdd(CO_KEY(idx, sub, CO_STRING|CO_OBJ____R_), CO_TSTRING, (CO_DATA)&Str23);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT SEGMENTED UPLOAD ==============*/
@@ -455,7 +455,7 @@ TS_DEF_MAIN(TS_SegRd_DomainNullPtr)
     uint8_t   sub  = 9;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), 0, (uintptr_t)0);
+    TS_ODAdd(CO_KEY(idx, sub, CO_UNSIGNED8|CO_OBJ____RW), 0, (CO_DATA)0);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT SEGMENTED DOWNLOAD  ===========*/
@@ -541,7 +541,7 @@ TS_DEF_MAIN(TS_SegRd_Bad2ndToggleBit)
     Str23.Start  = (uint8_t *)strPtr;
                                                       /*------------------------------------------*/
     TS_CreateMandatoryDir();
-    TS_ODAdd(CO_KEY(idx, sub, CO_STRING|CO_OBJ____R_), CO_TSTRING, (uintptr_t)&Str23);
+    TS_ODAdd(CO_KEY(idx, sub, CO_STRING|CO_OBJ____R_), CO_TSTRING, (CO_DATA)&Str23);
     TS_CreateNode(&node,0);
 
                                                       /*===== INIT SEGMENTED UPLOAD ==============*/

--- a/website/docs/api/object.md
+++ b/website/docs/api/object.md
@@ -10,7 +10,7 @@ classDiagram
   CO_OBJ_TYPE o-- CO_OBJ : Type
   class CO_OBJ {
     -uint32_t Key
-    -uintptr_t Data
+    -CO_DATA Data
     +COObjGetSize(width) uint32_t
     +COObjRdBufCont(destination, length) int16_t
     +COObjRdBufStart(destination, length) int16_t
@@ -28,7 +28,7 @@ The class `CO_OBJ` is defined within `co_obj.h` and is responsible for the CANop
 
 | Data Member | Type           | Description                        |
 | ----------- | -------------- | ---------------------------------- |
-| Data        | `uintptr_t`    | data information of object entry   |
+| Data        | `CO_DATA`      | data information of object entry   |
 | Key         | `uint32_t`     | Encoded object entry properties    |
 | Type        | `CO_OBJ_TYPE*` | pointer to object type             |
 

--- a/website/docs/examples/setup-calibration-mode.md
+++ b/website/docs/examples/setup-calibration-mode.md
@@ -125,7 +125,7 @@ Finally, in the standard parameter store/restore entries, we use a separate subi
 ```c
 const CO_OBJ ExampleObjDir[] = {
     :
-  { CO_KEY(0x1010, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&CalParaObj },
+  { CO_KEY(0x1010, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&CalParaObj },
     :
 };
 ```
@@ -139,9 +139,9 @@ const CO_OBJ ExampleObjDir[] = {
     :
   { CO_KEY(0x2F00, 0, CO_UNSIGNED8 |CO_OBJ_D__RW), 0u, 4u },
   { CO_KEY(0x2F00, 1, CO_UNSIGNED32|CO_OBJ_D___W), CO_TCAL, 0u },
-  { CO_KEY(0x2F00, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TCAL, (uintptr_t)&CalValue.Factor },
-  { CO_KEY(0x2F00, 3, CO_UNSIGNED32|CO_OBJ____RW), CO_TCAL, (uintptr_t)&CalValue.Divisor },
-  { CO_KEY(0x2F00, 4, CO_SIGNED32  |CO_OBJ____RW), CO_TCAL, (uintptr_t)&CalValue.Offset },
+  { CO_KEY(0x2F00, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TCAL, (CO_DATA)&CalValue.Factor },
+  { CO_KEY(0x2F00, 3, CO_UNSIGNED32|CO_OBJ____RW), CO_TCAL, (CO_DATA)&CalValue.Divisor },
+  { CO_KEY(0x2F00, 4, CO_SIGNED32  |CO_OBJ____RW), CO_TCAL, (CO_DATA)&CalValue.Offset },
     :
 };
 ```

--- a/website/docs/examples/setup-dynamic-object-dictionary.md
+++ b/website/docs/examples/setup-dynamic-object-dictionary.md
@@ -55,7 +55,7 @@ Some small local functions will help us to get the following implementations of 
 The service `ObjSet()` allows us to set the values of a single object entry to the given values.
 
 ```c
-static void ObjSet(CO_OBJ *obj, uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data)
+static void ObjSet(CO_OBJ *obj, uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data)
 {
   obj->Key  = key;
   obj->Type = type;
@@ -147,7 +147,7 @@ The function for adding a new object entry needs three arguments besides the obj
 - The last argument `data` holds the data of this object entry. The interpretation of this data depends on the flags in the argument `key`. We have a look at this relationship later in the examples.
 
 ```c
-void ODAddUpdate(OD_DYN *self, uint32_t key, const CO_OBJ_TYPE *type, uintptr_t data)
+void ODAddUpdate(OD_DYN *self, uint32_t key, const CO_OBJ_TYPE *type, CO_DATA data)
 {
   CO_OBJ  temp;
   CO_OBJ *od;

--- a/website/docs/examples/use-dynamic-object-dictionary.md
+++ b/website/docs/examples/use-dynamic-object-dictionary.md
@@ -34,7 +34,7 @@ First, we will take a look at all CiA DS301 object entries one by one. After get
 The device type is a 32bit value, which identifies the CANopen device. Due to the fact, that our demo is not a real CANopen device, we store a constant 32bit dummy value (0x00000000) in this entry.
 
 ```c
-ODAddUpdate(self, CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x00000000);
+ODAddUpdate(self, CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x00000000);
 ```
 
 We choose the additional flags `CO_OBJ_D__R_` to store the data directly (`D`) in the object entry and allow read access (`R`) from the communication interface.
@@ -45,7 +45,7 @@ We choose the additional flags `CO_OBJ_D__R_` to store the data directly (`D`) i
 The error register is an 8bit value, which holds the error register flags. The CANopen EMGY module manages the single error register flags.
 
 ```c
-ODAddUpdate(self, CO_KEY(0x1001, 0, CO_UNSIGNED32|CO_OBJ___PR_), 0, (uintptr_t)&ErrReg);
+ODAddUpdate(self, CO_KEY(0x1001, 0, CO_UNSIGNED32|CO_OBJ___PR_), 0, (CO_DATA)&ErrReg);
 ```
 
 For this entry, we choose the additional flags `CO_OBJ___PR_` to store a pointer to the data in the object entry (`_` instead of `D`), allow the PDO mapping (`P`) and allow read access (`R`) from the communication interface.
@@ -56,7 +56,7 @@ For this entry, we choose the additional flags `CO_OBJ___PR_` to store a pointer
 The heartbeat producer is a 16bit value, which holds the time in ms between two heartbeats. The entry is a system type, which injects the heartbeat callback functions into this entry. The callback functions are responsible for the system behavior when reading or writing this entry.
 
 ```c
-ODAddUpdate(self, CO_KEY(0x1017, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_THEARTBEAT, (uintptr_t)&HbTime);
+ODAddUpdate(self, CO_KEY(0x1017, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_THEARTBEAT, (CO_DATA)&HbTime);
 ```
 
 For the system type `CO_THEARTBEAT` we must choose the storage of a data pointer in the object directory (`_` instead of `D`). To get a system, which conforms to CiA DS301, we disallow the PDO mapping (`_` instead of `P`) and allow read (`R`) and write (`W`) access from the communication interface. Therefore we set the additional flags: `CO_OBJ____RW`.
@@ -67,8 +67,8 @@ For the system type `CO_THEARTBEAT` we must choose the storage of a data pointer
 The identity object is a structure of detailed node information. Due to the fact, that our demo is not a real CANopen device, we store a constant 32bit dummy value (0x00000000) in the mandatory entry at Sub-index 01h.
 
 ```c
-ODAddUpdate(self, CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0x01);
-ODAddUpdate(self, CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x00000000);
+ODAddUpdate(self, CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0x01);
+ODAddUpdate(self, CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x00000000);
 ```
 
 The subindex 00h holds the highest supported subindex in this index as a constant 8bit value.
@@ -91,9 +91,9 @@ static void ODCreateSDOServer(OD_DYN *self, uint8_t srv, uint32_t request, uint3
     request  = (uint32_t)0x600;
     response = (uint32_t)0x580;
   }
-  ODAddUpdate(self, CO_KEY(0x1200+srv, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0x02);
-  ODAddUpdate(self, CO_KEY(0x1200+srv, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (uintptr_t)request);
-  ODAddUpdate(self, CO_KEY(0x1200+srv, 2, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (uintptr_t)response);
+  ODAddUpdate(self, CO_KEY(0x1200+srv, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0x02);
+  ODAddUpdate(self, CO_KEY(0x1200+srv, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (CO_DATA)request);
+  ODAddUpdate(self, CO_KEY(0x1200+srv, 2, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (CO_DATA)response);
 }
 ```
 
@@ -106,11 +106,11 @@ Now we want to setup the transmit PDO (TPDO) communication object entry with a s
 ```c
 static void ODCreateTPDOCom(OD_DYN *self, uint8_t num, uint32_t id, uint8_t type, uint16_t inhibit, uint16_t evtimer)
 {
-  ODAddUpdate(self, CO_KEY(0x1800+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0x05);
-  ODAddUpdate(self, CO_KEY(0x1800+num, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (uintptr_t)id);
-  ODAddUpdate(self, CO_KEY(0x1800+num, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)type);
-  ODAddUpdate(self, CO_KEY(0x1800+num, 3, CO_UNSIGNED16|CO_OBJ_D__RW), 0, (uintptr_t)inhibit);
-  ODAddUpdate(self, CO_KEY(0x1800+num, 5, CO_UNSIGNED16|CO_OBJ_D__RW), CO_TEVENT, (uintptr_t)evtimer);
+  ODAddUpdate(self, CO_KEY(0x1800+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0x05);
+  ODAddUpdate(self, CO_KEY(0x1800+num, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, (CO_DATA)id);
+  ODAddUpdate(self, CO_KEY(0x1800+num, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)type);
+  ODAddUpdate(self, CO_KEY(0x1800+num, 3, CO_UNSIGNED16|CO_OBJ_D__RW), 0, (CO_DATA)inhibit);
+  ODAddUpdate(self, CO_KEY(0x1800+num, 5, CO_UNSIGNED16|CO_OBJ_D__RW), CO_TEVENT, (CO_DATA)evtimer);
 }
 ```
 
@@ -131,9 +131,9 @@ static void ODCreateTPdoMap(OD_DYN *self, uint8_t num, uint32_t *map, uint8_t le
 {
   uint8_t n;
 
-  ODAddUpdate(self, CO_KEY(0x1A00+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)len);
+  ODAddUpdate(self, CO_KEY(0x1A00+num, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)len);
   for (n = 0; n < len; n++) {
-    ODAddUpdate(self, CO_KEY(0x1A00+num, 1+n, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)map[n]);
+    ODAddUpdate(self, CO_KEY(0x1A00+num, 1+n, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)map[n]);
   }
 }
 ```
@@ -156,15 +156,15 @@ static void ODCreateDict(OD_DYN *self)
 
   Obj1001_00_08 = 0;
 
-  ODAddUpdate(self, CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x00000000);
-  ODAddUpdate(self, CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&Obj1001_00_08);
-  ODAddUpdate(self, CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x80);
-  ODAddUpdate(self, CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (uintptr_t)0);
-  ODAddUpdate(self, CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)4);
-  ODAddUpdate(self, CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
-  ODAddUpdate(self, CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
-  ODAddUpdate(self, CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
-  ODAddUpdate(self, CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0);
+  ODAddUpdate(self, CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x00000000);
+  ODAddUpdate(self, CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&Obj1001_00_08);
+  ODAddUpdate(self, CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x80);
+  ODAddUpdate(self, CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (CO_DATA)0);
+  ODAddUpdate(self, CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)4);
+  ODAddUpdate(self, CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
+  ODAddUpdate(self, CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
+  ODAddUpdate(self, CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
+  ODAddUpdate(self, CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0);
 
   ODCreateSDOServer(self, 0, CO_COBID_SDO_REQUEST(), CO_COBID_SDO_RESPONSE());
 
@@ -175,10 +175,10 @@ static void ODCreateDict(OD_DYN *self)
   map[2] = CO_LINK(0x2100, 3,  8);
   ODCreateTPdoMap(self, 0, map, 3);
 
-  ODAddUpdate(self, CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)3);
-  ODAddUpdate(self, CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_01_20);
-  ODAddUpdate(self, CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_02_08);
-  ODAddUpdate(self, CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (uintptr_t)&Obj2100_03_08);
+  ODAddUpdate(self, CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)3);
+  ODAddUpdate(self, CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_01_20);
+  ODAddUpdate(self, CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_02_08);
+  ODAddUpdate(self, CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (CO_DATA)&Obj2100_03_08);
 }
 ```
 

--- a/website/docs/examples/write-serial-number.md
+++ b/website/docs/examples/write-serial-number.md
@@ -64,7 +64,7 @@ We use our user type to define the calibration object entry:
 ```c
 const CO_OBJ ExampleObjDir[] = {
     :
-  { CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), CO_TOTP, (uintptr_t)&serialNo },
+  { CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), CO_TOTP, (CO_DATA)&serialNo },
     :
 };
 ```

--- a/website/docs/start/quickstart.md
+++ b/website/docs/start/quickstart.md
@@ -52,15 +52,15 @@ These mandatory entries are added with the following lines of code:
 
 ```c
   :
-{CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-{CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ____R_), 0, (uintptr_t)&Obj1001_00_08},
-{CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0x80},
-{CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (uintptr_t)0},
-{CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)4},
-{CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-{CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-{CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
-{CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (uintptr_t)0},
+{CO_KEY(0x1000, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+{CO_KEY(0x1001, 0, CO_UNSIGNED8 |CO_OBJ____R_), 0, (CO_DATA)&Obj1001_00_08},
+{CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0x80},
+{CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (CO_DATA)0},
+{CO_KEY(0x1018, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)4},
+{CO_KEY(0x1018, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+{CO_KEY(0x1018, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+{CO_KEY(0x1018, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
+{CO_KEY(0x1018, 4, CO_UNSIGNED32|CO_OBJ_D__R_), 0, (CO_DATA)0},
   :
 ```
 
@@ -94,7 +94,7 @@ The following lines add the SDO server entries to the object dictionary:
 
 ```c
   :
-{CO_KEY(0x1200, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)2},
+{CO_KEY(0x1200, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)2},
 {CO_KEY(0x1200, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, CO_COBID_SDO_REQUEST()},
 {CO_KEY(0x1200, 2, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, CO_COBID_SDO_RESPONSE()},
   :
@@ -119,10 +119,10 @@ These entries are created using the following lines of code:
 
 ```c
   :
-{CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)3},
-{CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_01_20},
-{CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&Obj2100_02_08},
-{CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (uintptr_t)&Obj2100_03_08},
+{CO_KEY(0x2100, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)3},
+{CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_01_20},
+{CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&Obj2100_02_08},
+{CO_KEY(0x2100, 3, CO_UNSIGNED8 |CO_OBJ___PR_), CO_TASYNC, (CO_DATA)&Obj2100_03_08},
   :
 ```
 
@@ -156,9 +156,9 @@ See the following lines in the object dictionary:
 
 ```c
   :
-{CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)2},
+{CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)2},
 {CO_KEY(0x1800, 1, CO_UNSIGNED32|CO_OBJ_DN_R_), 0, CO_COBID_TPDO_DEFAULT(0)},
-{CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)254},
+{CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)254},
   :
 ```
 
@@ -177,7 +177,7 @@ How we get these values is explained in section [configuration of PDO mapping][3
 
 ```c
   :
-{CO_KEY(0x1A00, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)3},
+{CO_KEY(0x1A00, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)3},
 {CO_KEY(0x1A00, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x01, 32)},
 {CO_KEY(0x1A00, 2, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x02,  8)},
 {CO_KEY(0x1A00, 3, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x03,  8)},

--- a/website/docs/usage/configuration.md
+++ b/website/docs/usage/configuration.md
@@ -101,20 +101,20 @@ The object entries, handling the saving and restoring of parameters, shall be se
 
 ```c
 { CO_KEY(0x1010, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, 0x03 },
-{ CO_KEY(0x1010, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&AllParaObj },
-{ CO_KEY(0x1010, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&ComParaObj },
-{ CO_KEY(0x1010, 3, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&AppParaObj },
+{ CO_KEY(0x1010, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&AllParaObj },
+{ CO_KEY(0x1010, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&ComParaObj },
+{ CO_KEY(0x1010, 3, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&AppParaObj },
 
 { CO_KEY(0x1011, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, 0x03 },
-{ CO_KEY(0x1011, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&AllParaObj },
-{ CO_KEY(0x1011, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&ComParaObj },
-{ CO_KEY(0x1011, 3, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&AppParaObj },
+{ CO_KEY(0x1011, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&AllParaObj },
+{ CO_KEY(0x1011, 2, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&ComParaObj },
+{ CO_KEY(0x1011, 3, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&AppParaObj },
 ```
 
 The single parameters are most likely used within the object directory. The example definition of an object entry is shown for one parameter:
 
 ```c
-{ CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), 0, (uintptr_t)&Para.App.DemoWord },
+{ CO_KEY(0x1017, 0, CO_UNSIGNED16|CO_OBJ____RW), 0, (CO_DATA)&Para.App.DemoWord },
 ```
 
 ### Domain Definition
@@ -144,7 +144,7 @@ The following descriptions explains the details of the structure members:
 The object entry, presenting the example domain above to the CANopen network, should be defined within the manufacturer-specific area (e.g. index 0x2500, subindex 0x00) with the following object directory entry definition line:
 
 ```c
-{ CO_KEY(0x2500, 0, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (uintptr_t)&AppDomain },
+{ CO_KEY(0x2500, 0, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (CO_DATA)&AppDomain },
 ```
 
 Note: The standard type implementation `CO_TDOMAIN` assumes, that the domain memory is located in RAM and is direct accessible. For other types of domain, a project-specific domain type shall be implemented.
@@ -175,8 +175,8 @@ The following descriptions explains the details of the structure members, which 
 The object entry, presenting the example domain above to the CANopen network, should be defined within the heartbeat consumer area (index 0x1016, subindex 0x01 ff.) with the following object directory entry definition line:
 
 ```c
-{ CO_KEY(0x1016, 0, CO_DOMAIN|CO_OBJ_D__R_),           0, (uintptr_t)1                },
-{ CO_KEY(0x1016, 1, CO_DOMAIN|CO_OBJ____RW), CO_THB_CONS, (uintptr_t)&AppHbConsumer_1 },
+{ CO_KEY(0x1016, 0, CO_DOMAIN|CO_OBJ_D__R_),           0, (CO_DATA)1                },
+{ CO_KEY(0x1016, 1, CO_DOMAIN|CO_OBJ____RW), CO_THB_CONS, (CO_DATA)&AppHbConsumer_1 },
 ```
 
 Note: Even, if the members "Time" and "NodeId" are static, the heartbeat consumer must be placed in RAM. There are multiple internal members for managing the heartbeat consumer included as well.
@@ -325,7 +325,7 @@ The object entry type structure reference [`CO_OBJ_TYPE *`] shall be set to one 
 
 #### Object Data Reference
 
-The object data reference [`uintptr_t`] shall be set in dependence to the object flags and the object type structure reference to different values.
+The object data reference [`CO_DATA`] shall be set in dependence to the object flags and the object type structure reference to different values.
 
 | Object Type   | Object Flags   | Required Content in Data Pointer          |
 | ------------- | -------------- | ----------------------------------------- |
@@ -374,7 +374,7 @@ const CO_OBJ AppObjDir[] = {
   {CO_KEY(0x1A00, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x02, 8)},
     :
   /* mapped object entry */
-  {CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (uintptr_t)&MyData},
+  {CO_KEY(0x2100, 2, CO_UNSIGNED8 |CO_OBJ___PR_), 0, (CO_DATA)&MyData},
     :
   CO_OBJ_DIR_ENDMARK
 };

--- a/website/docs/usage/dictionary.md
+++ b/website/docs/usage/dictionary.md
@@ -90,7 +90,7 @@ If this parameter group is controllable from the CAN network side, the standard 
 ```c
 const CO_OBJ DemoObjDir[] = {
     :
-  { CO_KEY(0x1010, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (uintptr_t)&DemoParaObj },
+  { CO_KEY(0x1010, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TPARA, (CO_DATA)&DemoParaObj },
     :
 };
 ```
@@ -100,7 +100,7 @@ The parameter values itself can be used within any object directory entry. The f
 ```c
 const CO_OBJ DemoObjDir[] = {
     :
-  { CO_KEY(0x1234,0x56, CO_UNSIGNED32|CO_OBJ____RW), 0, (uintptr_t)&(DemoParaMem.ParaLong) },
+  { CO_KEY(0x1234,0x56, CO_UNSIGNED32|CO_OBJ____RW), 0, (CO_DATA)&(DemoParaMem.ParaLong) },
     :
 };
 ```
@@ -146,7 +146,7 @@ To enable the usage of this domain to the CAN network side, the domain object mu
 ```c
 const CO_OBJ DemoObjDir[] = {
     :
-  { CO_KEY(0x2345, 0, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (uintptr_t)&DemoDomainObj },
+  { CO_KEY(0x2345, 0, CO_DOMAIN|CO_OBJ____RW), CO_TDOMAIN, (CO_DATA)&DemoDomainObj },
     :
 };
 ```
@@ -173,7 +173,7 @@ To enable the usage of this string to the CAN network side, the string must be a
 ```c
 const CO_OBJ DemoObjDir[] = {
     :
-  { CO_KEY(0x3456, 0, CO_STRING|CO_OBJ____R_), CO_TSTRING, (uintptr_t)&DemoStringObj },
+  { CO_KEY(0x3456, 0, CO_STRING|CO_OBJ____R_), CO_TSTRING, (CO_DATA)&DemoStringObj },
     :
 };
 ```
@@ -213,7 +213,7 @@ To enable the usage of this demo type to the CAN network side, the demo object m
 
 const CO_OBJ DemoObjDir[] = {
     :
-  { CO_KEY(0x6789, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TDEMO, (uintptr_t)&DemoValue },
+  { CO_KEY(0x6789, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TDEMO, (CO_DATA)&DemoValue },
     :
 };
 ```

--- a/website/docs/usage/tpdo.md
+++ b/website/docs/usage/tpdo.md
@@ -22,11 +22,11 @@ For a constant timer based sending as defined in the CiA standards we need to pr
 
 ```c
   :
-{CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)5},
+{CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)5},
 {CO_KEY(0x1800, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_COBID_TPDO_DEFAULT(0)},
-{CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0xfe},
-{CO_KEY(0x1800, 3, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (uintptr_t)0},
-{CO_KEY(0x1800, 5, CO_UNSIGNED16|CO_OBJ_D__R_), CO_TEVENT, (uintptr_t)60},
+{CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0xfe},
+{CO_KEY(0x1800, 3, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (CO_DATA)0},
+{CO_KEY(0x1800, 5, CO_UNSIGNED16|CO_OBJ_D__R_), CO_TEVENT, (CO_DATA)60},
   :
 ```
 
@@ -67,15 +67,15 @@ The transmit on change of an object entry is described in the quickstart. This t
 
 ```c
   :
-{CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)2},
+{CO_KEY(0x1800, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)2},
 {CO_KEY(0x1800, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_COBID_TPDO_DEFAULT(0)},
-{CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)254}
-{CO_KEY(0x1800, 3, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (uintptr_t)100}
+{CO_KEY(0x1800, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)254}
+{CO_KEY(0x1800, 3, CO_UNSIGNED16|CO_OBJ_D__R_), 0, (CO_DATA)100}
   :
-{CO_KEY(0x1A00, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)1},
+{CO_KEY(0x1A00, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)1},
 {CO_KEY(0x1A00, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_LINK(0x2100, 0x01, 32)},
   :
-{CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TASYNC, (uintptr_t)&MyValue},
+{CO_KEY(0x2100, 1, CO_UNSIGNED32|CO_OBJ____RW), CO_TASYNC, (CO_DATA)&MyValue},
   :
 ```
 
@@ -94,8 +94,8 @@ For triggering the PDO transmissions on all remote nodes in the network, we need
 uint32_t obj1005 = CO_SYNC_COBID_ON | 0x80;    /* enable sync producer       */
 uint32_t obj1006 = 20 * 1000;                  /* sync cycle-time 20ms in us */
   :
-{CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TSYNCID, (uintptr_t)(&obj1005)},
-{CO_KEY(0x1006, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TSYNCCYCLE, (uintptr_t)(&obj1006)},
+{CO_KEY(0x1005, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TSYNCID, (CO_DATA)(&obj1005)},
+{CO_KEY(0x1006, 0, CO_UNSIGNED32|CO_OBJ____RW), CO_TSYNCCYCLE, (CO_DATA)(&obj1006)},
   :
 ```
 
@@ -109,9 +109,9 @@ The CiA standard defines synchronous PDO transfers, too. This allows the transmi
 
 ```c
   :
-{CO_KEY(0x1807, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)2},
+{CO_KEY(0x1807, 0, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)2},
 {CO_KEY(0x1807, 1, CO_UNSIGNED32|CO_OBJ_D__R_), 0, CO_COBID_TPDO_DEFAULT(0)},
-{CO_KEY(0x1807, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (uintptr_t)0x4},
+{CO_KEY(0x1807, 2, CO_UNSIGNED8 |CO_OBJ_D__R_), 0, (CO_DATA)0x4},
   :
 ```
 


### PR DESCRIPTION
Introduce the datatype CO_DATA to allow direct storage of values on 16bit microcontrollers, too.