### PR TITLE
Add the capability to translate the T/RPDO number to a virtual one

### DIFF
--- a/src/core/co_err.h
+++ b/src/core/co_err.h
@@ -91,6 +91,7 @@ typedef enum CO_ERR_T {
 
     CO_ERR_TPDO_COM_OBJ,         /*!< config error in TPDO communication     */
     CO_ERR_TPDO_MAP_OBJ,         /*!< config error in TPDO mapping           */
+    CO_ERR_TPDO_TRANSLATE,       /*!< config error in TPDO number translation*/
     CO_ERR_TPDO_OBJ_TRIGGER,     /*!< error during trigger via an object     */
     CO_ERR_TPDO_NUM_TRIGGER,     /*!< error during trigger via an PDO number */
     CO_ERR_TPDO_INHIBIT,         /*!< error during inhibit timer creation    */
@@ -98,6 +99,7 @@ typedef enum CO_ERR_T {
 
     CO_ERR_RPDO_COM_OBJ,         /*!< config error in RPDO communication     */
     CO_ERR_RPDO_MAP_OBJ,         /*!< config error in RPDO mapping           */
+    CO_ERR_RPDO_TRANSLATE,       /*!< config error in RPDO number translation*/
 
     CO_ERR_SDO_SILENT,           /*!< no SDO response (e.g. block transfer)  */
     CO_ERR_SDO_OFF,              /*!< SDO client is disabled                 */

--- a/src/service/cia301/co_pdo.h
+++ b/src/service/cia301/co_pdo.h
@@ -203,6 +203,7 @@ typedef struct CO_TPDO_T {
     uint32_t          Inhibit;     /*!< inhibit time in timer ticks          */
     uint8_t           Flags;       /*!< info flags                           */
     uint8_t           ObjNum;      /*!< Number of linked objects             */
+    int16_t           NumTransl;   /*!< TPDO number translated to            */
 
 } CO_TPDO;
 
@@ -218,6 +219,7 @@ typedef struct CO_RPDO_T {
     uint8_t           Size[8];     /*!< size of mapped object value in bytes */
     uint8_t           ObjNum;      /*!< Number of linked objects             */
     uint8_t           Flag;        /*!< Flags attributed of PDO              */
+    int16_t           NumTransl;   /*!< RPDO number translated to            */
 
 } CO_RPDO;
 
@@ -251,6 +253,38 @@ void COTPdoTrigObj(CO_TPDO *tpdo, struct CO_OBJ_T *obj);
 *    Number of TPDO (0..511)
 */
 void COTPdoTrigPdo(CO_TPDO *tpdo, uint16_t num);
+
+/*! \brief TPDO TRANSLATE TPDO-NUM
+*
+*    This function allows the application to translate a TPDO number to a
+*    different given TPDO number.
+*
+* \param tpdo
+*    Pointer to start of TPDO array
+*
+* \param num
+*    Number of TPDO (0..511)
+*
+* \param num_translate
+*    Number of TPDO to translate into (0..511)
+*/
+void COTPdoTranslatePdo(CO_TPDO *pdo, uint16_t num, uint16_t num_translate);
+
+/*! \brief RPDO TRANSLATE RPDO-NUM
+*
+*    This function allows the application to translate a RPDO number to a
+*    different given RPDO number.
+*
+* \param tpdo
+*    Pointer to start of RPDO array
+*
+* \param num
+*    Number of RPDO (0..511)
+*
+* \param num_translate
+*    Number of RPDO to translate into (0..511)
+*/
+void CORPdoTranslatePdo(CO_RPDO *pdo, uint16_t num, uint16_t num_translate);
 
 /******************************************************************************
 * PRIVATE FUNCTIONS


### PR DESCRIPTION
At the moment the PDO number is bound to the PDO index that is usually [0..3]. But if we want to use for example TPDO48 we should have 48 TPDOs and this consumes a lot ram. To avoid this let's introduce 2 new apis: COTPdoTranslatePdo()
CORPdoTranslatePdo()
that allow to bind a PDO to a translated number. This way we can for example use TPDO[0] as TPDO48.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>