### PR TITLE
Callback function for RPDO which are not synchronous

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,20 +2,11 @@
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		// programming in C
-		"editorconfig.editorconfig",
 		"ms-vscode.cpptools",
-		"jbenden.c-cpp-flylint",
 		// build environment
 		"twxs.cmake",
 		"ms-vscode.cmake-tools",
-		"fredericbonnet.cmake-test-adapter",
-		// version control
-		"mhutchie.git-graph",
-		"eamodio.gitlens",
-		// documentation
-		"yzhang.markdown-all-in-one",
-		// target debugging Cortex-M
-		"marus25.cortex-debug"
+		"fredericbonnet.cmake-test-adapter"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,42 +1,5 @@
 {
   "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
   "cmake.configureOnOpen": true,
-
-  "cmakeExplorer.suiteDelimiter": "/",
-
-  "c-cpp-flylint.debug": true,
-  "c-cpp-flylint.run": "onBuild",
-
-  "c-cpp-flylint.clang.enable": false,
-  "c-cpp-flylint.flawfinder.enable": false,
-  "c-cpp-flylint.flexelint.enable": false,
-  "c-cpp-flylint.lizard.enable": false,
-
-  "c-cpp-flylint.cppcheck.enable": true,
-  "c-cpp-flylint.cppcheck.language": "c",
-  "c-cpp-flylint.cppcheck.standard": [ "c99" ],
-  "c-cpp-flylint.cppcheck.force": true,
-  "c-cpp-flylint.cppcheck.suppressions": [
-    "variableScope",          // reason: we want to declare all used variables in a function at the top
-    "unusedStructMember",     // reason: we provide structures for use in the application
-    "comparePointers",        // reason: we need to loop through the testcase structures in the test section
-    "constParameter",         // reason: we want to avoid const parameters for easier function usage
-    "ConfigurationNotChecked" // reason: we want to avoid problems with the C test framework 'acutest.h'
-  ],
-  "c-cpp-flylint.cppcheck.includePaths": [
-    // CANopen Library
-    "src/config",
-    "src/core",
-    "src/hal",
-    "src/object/basic",
-    "src/object/cia301",
-    "src/service/cia301",
-    "src/service/cia305",
-    // Library Testing
-    "tests/integration/app",
-    "tests/integration/driver",
-    "tests/integration/testfrm",
-    "tests/integration/tests",
-    "tests/unit/env",
-  ]
+  "cmakeExplorer.suiteDelimiter": "/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and starting with version 4.1.0 this project adheres to [Semantic Versioning](ht
 
 ## [unreleased]
 
-nothing
+### Change
+
+- Replace sizeof() operators with the constant value
 
 ## [4.4.0] - 2022-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and starting with version 4.1.0 this project adheres to [Semantic Versioning](ht
 ### Change
 
 - Replace sizeof() operators with the constant value
+- Add error checking in COTPdoMapWrite [ezrec](https://github.com/ezrec)
 
 ## [4.4.0] - 2022-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and starting with version 4.1.0 this project adheres to [Semantic Versioning](ht
 
 ### Change
 
-- Replace sizeof() operators with the constant value
 - Add error checking in COTPdoMapWrite [ezrec](https://github.com/ezrec)
+- Fix RPDO dummy mapping [mrk-its](https://github.com/mrk-its)
 
 ## [4.4.0] - 2022-08-21
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,6 +8,7 @@
       "binaryDir": "build",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     }

--- a/README.md
+++ b/README.md
@@ -50,12 +50,20 @@ The source code is compliant to the C99 standard and you must cross-compile the 
 
 ## Usage
 
-With version 4.4, the CANopen Stack project introduces an ecosystem that tries to support you in your project management. This support uses multiple repositories for essential aspects of an embedded software project setup:
+With version 4.4, the CANopen Stack project introduces an ecosystem which supports you in managing target specific applications. This support uses multiple repositories for different aspects of the embedded software project setup:
 
 - **[cmake-scripts](https://github.com/embedded-office/cmake-scripts)** - this repository is responsible for the embedded toolchains and the component package management.
 - **[canopen-stack](https://github.com/embedded-office/canopen-stack)** - this repository represents the platform independent CANopen stack component.
-- **[canopen-stm32f7xx](https://github.com/embedded-office/canopen-stm32f7xx)** - this repository contains a complete Quickstart example setup for the device STM32F769. The adaption to other devices out of the STM32F7 series are small.
+
+### Embedded Target: STM32F7 series
+
+- **[canopen-stm32f7xx](https://github.com/embedded-office/canopen-stm32f7xx)** - this repository contains a complete Quickstart example setup for the device `STM32F769`.
 - **[STM32CubeF7](https://github.com/embedded-office/STM32CubeF7)** - this fork of the ST Microelectronics HAL package is integrated into the CMake build system and packaged with minimal required source files to get the ST HAL/LL drivers working (No middleware and documentation).
+
+### Embedded Target: STM32F4 series
+
+- **[canopen-stm32f4xx](https://github.com/embedded-office/canopen-stm32f4xx)** - this repository contains a complete Quickstart example setup for the device `STM32F446`.
+- **[STM32CubeF4](https://github.com/embedded-office/STM32CubeF4)** - this fork of the ST Microelectronics HAL package is integrated into the CMake build system and packaged with minimal required source files to get the ST HAL/LL drivers working (No middleware and documentation).
 
 ## Add Component in CMake (recommended)
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,22 @@ Download and install these free tools for your system:
 - Install the build tools [Cmake](https://cmake.org/)
 - Install the build system [Ninja](https://ninja-build.org/)
 - Install the static checker [cppcheck](http://cppcheck.net/)
+
+#### Linux and Mac
+
 - Install the compiler [LLVM](https://clang.llvm.org/)
 
-*Note: on my Windows machine, I use the [Visual Studio 2019 Build Tools](https://visualstudio.microsoft.com/de/downloads) which inlcudes the LLVM compiler and the required Windows SDK libraries.*
+#### Windows
 
+- Install the [Build Tools for Visual Studio 2019](https://my.visualstudio.com/Downloads?q=Build%20Tools%20for%20Visual%20Studio%202019) with the folowing components selected:
+
+  - MSVC v142 - VS 2019 C++
+
+  - Windows 10 SDK
+
+  - C++-CLang-Tools for Windows
+
+  *Note: Add the clang.exe binary path to the path environment variable so cmake can find it (On my machine: `%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\VC\Tools\Llvm\bin`)*
 
 ## Run the Test Applications
 

--- a/src/config/callbacks.c
+++ b/src/config/callbacks.c
@@ -190,6 +190,17 @@ void COPdoSyncUpdate(CO_RPDO *pdo)
 }
 
 WEAK
+void COPdoAsyncUpdate(CO_RPDO *pdo)
+{
+    (void)pdo;
+
+    /* Optional: place here some code, which is called
+     * right after the object dictionary update due to
+     * a asynchronous PDO.
+     */
+}
+
+WEAK
 int16_t COParaDefault(struct CO_PARA_T *pg)
 {
     (void)pg;

--- a/src/core/co_dict.c
+++ b/src/core/co_dict.c
@@ -239,8 +239,8 @@ CO_ERR CODictObjInit(CO_DICT *cod, CO_NODE *node)
     CO_ERR    err;
     CO_OBJ   *obj;
 
-    ASSERT_PTR_ERR(cod,  -1);
-    ASSERT_PTR_ERR(node, -1);
+    ASSERT_PTR_ERR(cod,  CO_ERR_BAD_ARG);
+    ASSERT_PTR_ERR(node, CO_ERR_BAD_ARG);
 
     obj = cod->Root;
     while (obj->Key != 0) {

--- a/src/core/co_obj.c
+++ b/src/core/co_obj.c
@@ -68,8 +68,15 @@ CO_ERR COObjRdBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *bu
 
     type = obj->Type;
     if (type->Read != NULL) {
+        /* mandatory: reset object */
         (void)COObjReset(obj, node, 0);
-        result = type->Read(obj, node, (void *)buffer, size);
+
+        /* optional: read from object */
+        if (size > 0) {
+            result = type->Read(obj, node, (void *)buffer, size);
+        } else {
+            result = CO_ERR_NONE;
+        }
     }
     return (result);
 }
@@ -91,6 +98,7 @@ CO_ERR COObjRdBufCont(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buf
     return (result);
 }
 
+
 CO_ERR COObjWrBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *buffer, uint32_t size)
 {
     const CO_OBJ_TYPE *type;
@@ -103,8 +111,15 @@ CO_ERR COObjWrBufStart(struct CO_OBJ_T *obj, struct CO_NODE_T *node, uint8_t *bu
 
     type = obj->Type;
     if (type->Write != NULL) {
+        /* mandatory: reset object */
         (void)COObjReset(obj, node, 0);
-        result = type->Write(obj, node, (void *)buffer, size);
+
+        /* optional: write to object */
+        if (size > 0) {
+            result = type->Write(obj, node, (void *)buffer, size);
+        } else {
+            result = CO_ERR_NONE;
+        }
     }
     return (result);
 }

--- a/src/driver/_template/drv_can_dummy.c
+++ b/src/driver/_template/drv_can_dummy.c
@@ -21,7 +21,7 @@
 /* TODO: rename the include file name to match the naming convention:
  *   co_can_<device>.h
  */
-#include "co_can_dummy.h"
+#include "drv_can_dummy.h"
 
 /******************************************************************************
 * PRIVATE DEFINES

--- a/src/driver/_template/drv_nvm_dummy.c
+++ b/src/driver/_template/drv_nvm_dummy.c
@@ -21,7 +21,7 @@
 /* TODO: rename the include file name to match the naming convention:
  *   co_nvm_<device>.h
  */
-#include "co_nvm_dummy.h"
+#include "drv_nvm_dummy.h"
 
 /******************************************************************************
 * PRIVATE DEFINES

--- a/src/driver/_template/drv_timer_dummy.c
+++ b/src/driver/_template/drv_timer_dummy.c
@@ -21,7 +21,7 @@
 /* TODO: rename the include file name to match the naming convention:
  *   co_timer_<device>.h
  */
-#include "co_timer_dummy.h"
+#include "drv_timer_dummy.h"
 
 /******************************************************************************
 * PRIVATE DEFINES

--- a/src/object/cia301/co_emcy_hist.c
+++ b/src/object/cia301/co_emcy_hist.c
@@ -199,7 +199,7 @@ void COEmcyHistAdd(CO_EMCY *emcy, uint8_t err, CO_EMCY_USR *usr)
         val |= (((uint32_t)usr->Hist) << 16);
     }
     obj = CODictFind(cod, CO_DEV(COT_OBJECT, sub));
-    (void)uint32->Write(obj, node, &val, sizeof(val));
+    (void)uint32->Write(obj, node, &val, 4);
 
     /* update number of stored entries in history */
     emcy->Hist.Num++;
@@ -207,7 +207,7 @@ void COEmcyHistAdd(CO_EMCY *emcy, uint8_t err, CO_EMCY_USR *usr)
         emcy->Hist.Num = emcy->Hist.Max;
     } else {
         obj = CODictFind(cod, CO_DEV(COT_OBJECT, 0));
-        (void)uint8->Write(obj, node, &(emcy->Hist.Num), sizeof(emcy->Hist.Num));
+        (void)uint8->Write(obj, node, &(emcy->Hist.Num), 1);
     }
 }
 
@@ -239,12 +239,12 @@ void COEmcyHistReset(CO_EMCY *emcy)
         node->Error = CO_ERR_NONE;
         return;
     }
-    (void)uint8->Write(obj, node, &val08, sizeof(val08));
+    (void)uint8->Write(obj, node, &val08, 1);
 
     /* clear all emergency entries in history */
     for (sub = 1; sub <= emcy->Hist.Max; sub++) {
         obj = CODictFind(cod, CO_DEV(COT_OBJECT, sub));
-        (void)uint32->Write(obj, node, &val32, sizeof(val32));
+        (void)uint32->Write(obj, node, &val32, 4);
     }
 
     /* update history state */

--- a/src/object/cia301/co_emcy_id.c
+++ b/src/object/cia301/co_emcy_id.c
@@ -70,14 +70,14 @@ static CO_ERR COTEmcyIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     ASSERT_EQU_ERR(size, COT_ENTRY_SIZE, CO_ERR_BAD_ARG);
 
     newId = *(uint32_t*)buffer;
-    (void)uint32->Read(obj, node, &oldId, sizeof(oldId));
+    (void)uint32->Read(obj, node, &oldId, 4);
 
     /* when current entry is active, bits 0 to 29 shall not be changed */
     if ((oldId & CO_EMCY_COBID_OFF) == (uint32_t)0) {
         if ((newId & CO_EMCY_COBID_MASK) != (oldId & CO_EMCY_COBID_MASK)) {
             result = CO_ERR_OBJ_RANGE;
         } else {
-            result = uint32->Write(obj, node, &newId, sizeof(newId));
+            result = uint32->Write(obj, node, &newId, 4);
         }
     } else {
         /* Conformance Test case : 2.11 - Test name : SDO 11
@@ -87,7 +87,7 @@ static CO_ERR COTEmcyIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
          * SDO 11: Valid abort codes are 06090030h, 06090032h or 08000000h
          */
         if (newId >= COT_COBID_MIN) {
-            result = uint32->Write(obj, node, &newId, sizeof(newId));
+            result = uint32->Write(obj, node, &newId, 4);
         } else {
             result = CO_ERR_OBJ_RANGE;
         }

--- a/src/object/cia301/co_hb_cons.c
+++ b/src/object/cia301/co_hb_cons.c
@@ -133,7 +133,7 @@ static CO_ERR COTNmtHbConsInit(struct CO_OBJ_T *obj, struct CO_NODE_T *node)
     if (CO_GET_IDX(obj->Key) == COT_OBJECT) {
         if (CO_GET_SUB(obj->Key) == 0) {
             /* loop through configured number of consumers */
-            (void)uint8->Read(obj, node, &num, sizeof(num));
+            (void)uint8->Read(obj, node, &num, 1);
             while (num > 0) {
                 /* check if consumer subindex exists */
                 obj = CODictFind(&node->Dict, CO_DEV(COT_OBJECT, num));

--- a/src/object/cia301/co_hb_prod.c
+++ b/src/object/cia301/co_hb_prod.c
@@ -113,7 +113,7 @@ static CO_ERR COTNmtHbProdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, vo
         }
 
         /* use basic type to update the object entry */
-        result = uint16->Write(obj, node, &cycTime, sizeof(cycTime));
+        result = uint16->Write(obj, node, &cycTime, 2);
     }
     return (result);
 }
@@ -145,7 +145,7 @@ static CO_ERR COTNmtHbProdInit(struct CO_OBJ_T *obj, struct CO_NODE_T *node)
         }
 
         /* start heartbeat producer timer with given cycletime */
-        (void)uint16->Read(obj, node, &cycTime, sizeof(cycTime));
+        (void)uint16->Read(obj, node, &cycTime, 2);
         if (cycTime > 0) {
             ticks = COTmrGetTicks(tmr, cycTime, CO_TMR_UNIT_1MS);
             nmt->Tmr = COTmrCreate(tmr,

--- a/src/object/cia301/co_para_store.c
+++ b/src/object/cia301/co_para_store.c
@@ -174,7 +174,7 @@ static CO_ERR COTParaStoreReset(struct CO_OBJ_T *obj, struct CO_NODE_T *node, ui
 
     /* we use reset on subindex 0 to load all parameter groups of a given type */
     if (CO_DEV(COT_OBJECT, 0) == CO_GET_DEV(obj->Key)) {
-        result = CONodeParaLoad(node, para);
+        result = CONodeParaLoad(node, (enum CO_NMT_RESET_T)para);
     }
     return (result);
 }

--- a/src/object/cia301/co_pdo_id.c
+++ b/src/object/cia301/co_pdo_id.c
@@ -98,10 +98,10 @@ static CO_ERR COTPdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
         num  = pcomidx & COT_OBJECT_NUM;
     }
 
-    (void)uint32->Read(obj, node, &oid, sizeof(oid));
+    (void)uint32->Read(obj, node, &oid, 4);
     if ((oid & CO_TPDO_COBID_OFF) == 0) {
         if ((nid & CO_TPDO_COBID_OFF) != 0) {
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, 4);
             if (nmt->Mode == CO_OPERATIONAL) {
                 if (tpdo != 0) {
                     COTPdoReset(tpdo, num);
@@ -115,9 +115,9 @@ static CO_ERR COTPdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
         }
     } else {
         if ((nid & CO_TPDO_COBID_OFF) != 0) {
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, 4);
         } else {
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, 4);
             if (nmt->Mode == CO_OPERATIONAL) {
                 if (tpdo != 0) {
                     COTPdoReset(tpdo, num);

--- a/src/object/cia301/co_pdo_map.c
+++ b/src/object/cia301/co_pdo_map.c
@@ -121,7 +121,7 @@ static CO_ERR COTPdoMapWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     }
 
     /* ok, write new PDO mapping */
-    result = uint32->Write(obj, node, &map, sizeof(map));
+    result = uint32->Write(obj, node, &map, 4);
     return (result);
 }
 

--- a/src/object/cia301/co_pdo_map.c
+++ b/src/object/cia301/co_pdo_map.c
@@ -73,6 +73,7 @@ static CO_ERR COTPdoMapWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     uint16_t  pmapidx;
     uint16_t  pcomidx;
     uint8_t   mapn;
+    CO_ERR    err;
 
     CO_UNUSED(size);
     ASSERT_PTR_ERR(obj, CO_ERR_BAD_ARG);
@@ -84,13 +85,19 @@ static CO_ERR COTPdoMapWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     map     = *(uint32_t*)buffer;
 
     /* check that PDO is inactive */
-    (void)CODictRdLong(cod, CO_DEV(pcomidx, 1), &id);
+    err = CODictRdLong(cod, CO_DEV(pcomidx, 1), &id);
+    if (err != CO_ERR_NONE) {
+        return err;
+    }
     if ((id & CO_TPDO_COBID_OFF) == 0) {
         return (CO_ERR_OBJ_ACC);
     }
 
     /* check number of PDO mapping entries */
-    (void)CODictRdByte(cod, CO_DEV(pmapidx, 0), &mapn);
+    err = CODictRdByte(cod, CO_DEV(pmapidx, 0), &mapn);
+    if (err != CO_ERR_NONE) {
+        return err;
+    }
     if (mapn != 0) {
         return (CO_ERR_OBJ_ACC);
     }

--- a/src/object/cia301/co_pdo_num.c
+++ b/src/object/cia301/co_pdo_num.c
@@ -107,7 +107,7 @@ static CO_ERR COTPdoNumWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     }
 
     /* finaly: store new number of PDO mappings */
-    result = uint8->Write(obj, node, &mapnum, sizeof(mapnum));
+    result = uint8->Write(obj, node, &mapnum, 1);
     return (result);
 }
 

--- a/src/object/cia301/co_pdo_type.c
+++ b/src/object/cia301/co_pdo_type.c
@@ -85,7 +85,7 @@ static CO_ERR COTPdoTypeWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void
 
     /* write new PDO type */
     type    = *(uint8_t*)buffer;
-    result = uint8->Write(obj, node, &type, sizeof(type));
+    result = uint8->Write(obj, node, &type, 1);
     return (result);
 }
 

--- a/src/object/cia301/co_sdo_id.c
+++ b/src/object/cia301/co_sdo_id.c
@@ -74,12 +74,12 @@ static CO_ERR COTSdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
     ASSERT_EQU_ERR(size, 4u, CO_ERR_BAD_ARG);
 
     newval = *(uint32_t *)buffer;
-    (void)uint32->Read(obj, node, &curval, sizeof(curval));
+    (void)uint32->Read(obj, node, &curval, 4);
     num = CO_GET_IDX(obj->Key) & 0x7F;
 
     if ((curval & CO_SDO_ID_OFF) == 0) {
         if ((newval & CO_SDO_ID_OFF) != 0) {
-            err = uint32->Write(obj, node, &newval, sizeof(newval));
+            err = uint32->Write(obj, node, &newval, 4);
             if (err == CO_ERR_NONE) {
                 COSdoReset(node->Sdo, num, node);
             }
@@ -87,7 +87,7 @@ static CO_ERR COTSdoIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void *
             return (CO_ERR_OBJ_RANGE);
         }
     } else {
-        err = uint32->Write(obj, node, &newval, sizeof(newval));
+        err = uint32->Write(obj, node, &newval, 4);
     }
     if (err == CO_ERR_NONE) {
         COSdoEnable(node->Sdo, num);

--- a/src/object/cia301/co_sync_cycle.c
+++ b/src/object/cia301/co_sync_cycle.c
@@ -77,9 +77,9 @@ static CO_ERR COTSyncCycleWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, vo
      * Fetch old settings (will be restored in
      * case producer reactivation went wrong
      */
-    (void)uint32->Read(obj, node, &ous, sizeof(ous));
+    (void)uint32->Read(obj, node, &ous, 4);
 
-    result = uint32->Write(obj, node, &nus, sizeof(nus));
+    result = uint32->Write(obj, node, &nus, 4);
     if (result != CO_ERR_NONE) {
         return CO_ERR_OBJ_RANGE;
     }
@@ -96,7 +96,7 @@ static CO_ERR COTSyncCycleWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, vo
              * Object write access was successful once already,
              * no result check is needed.
              */
-            (void)uint32->Write(obj, node, &ous, sizeof(ous));
+            (void)uint32->Write(obj, node, &ous, 4);
             sync->Cycle = ous;
             result      = CO_ERR_OBJ_RANGE;
         }

--- a/src/object/cia301/co_sync_id.c
+++ b/src/object/cia301/co_sync_id.c
@@ -71,7 +71,7 @@ static CO_ERR COTSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
 
     sync = &node->Sync;
     nid = *(uint32_t*)buffer;
-    (void)uint32->Read(obj, node, &oid, sizeof(oid));
+    (void)uint32->Read(obj, node, &oid, 4);
 
     /* when current entry is generating SYNCs, bits 0 to 29 shall not be changed */
     if ((oid & CO_SYNC_COBID_ON) != (uint32_t)0) {
@@ -83,7 +83,7 @@ static CO_ERR COTSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
                 COSyncProdDeactivate(sync);
             }
             sync->CobId = nid;
-            result = uint32->Write(obj, node, &nid, sizeof(nid));
+            result = uint32->Write(obj, node, &nid, 4);
             if (result != CO_ERR_NONE) {
                 result = CO_ERR_OBJ_RANGE;
             }
@@ -104,7 +104,7 @@ static CO_ERR COTSyncIdWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
             }
         }
         sync->CobId = nid;
-        result = uint32->Write(obj, node, &nid, sizeof(nid));
+        result = uint32->Write(obj, node, &nid, 4);
         if (result != CO_ERR_NONE) {
             result = CO_ERR_OBJ_RANGE;
         }

--- a/src/service/cia301/co_pdo.c
+++ b/src/service/cia301/co_pdo.c
@@ -545,6 +545,7 @@ void CORPdoRx(CO_RPDO *pdo, CO_IF_FRM *frm)
     if (err == 0) {
         if ((pdo->Flag & CO_RPDO_FLG_S_) == 0) {
             CORPdoWrite(pdo, frm);
+            COPdoAsyncUpdate(pdo);
         } else {
             COSyncRx(&pdo->Node->Sync, frm);
         }

--- a/src/service/cia301/co_pdo.h
+++ b/src/service/cia301/co_pdo.h
@@ -51,6 +51,14 @@ extern "C" {
 #define CO_RPDO_FLG__E      0x01                    /*!< enabled RPDO        */
 #define CO_RPDO_FLG_S_      0x02                    /*!< synchronized RPDO   */
 
+#define CO_RPDO_MAP_DUMMY_I8    0x00020008      /* RPDO Map Dummy INTEGER8   */
+#define CO_RPDO_MAP_DUMMY_I16   0x00030010      /* RPDO Map Dummy INTEGER16  */
+#define CO_RPDO_MAP_DUMMY_I24   0x00100018      /* RPDO Map Dummy INTEGER24  */
+#define CO_RPDO_MAP_DUMMY_I32   0x00040020      /* RPDO Map Dummy INTEGER32  */
+#define CO_RPDO_MAP_DUMMY_U8    0x00050008      /* RPDO Map Dummy UNSIGNED8  */
+#define CO_RPDO_MAP_DUMMY_U16   0x00060010      /* RPDO Map Dummy UNSIGNED16 */
+#define CO_RPDO_MAP_DUMMY_U24   0x00160018      /* RPDO Map Dummy UNSIGNED24 */
+#define CO_RPDO_MAP_DUMMY_U32   0x00070020      /* RPDO Map Dummy UNSIGNED32 */
 
 /*! \brief RPDO COB-ID parameter
 *

--- a/src/service/cia301/co_pdo.h
+++ b/src/service/cia301/co_pdo.h
@@ -539,6 +539,16 @@ extern void COPdoTransmit(CO_IF_FRM *frm);
 */
 extern int16_t COPdoReceive(CO_IF_FRM *frm);
 
+/*! \brief  ASYNC UPDATE
+*
+*    This function is called just after the asynchronous RPDO is written to
+*    the object dictionary.
+*
+* \param pdo
+*    Pointer to received RPDO
+*/
+extern void COPdoAsyncUpdate(CO_RPDO *pdo);
+
 /*! \brief  PDO WRITE DATA CALLBACK
 *
 *    This function is called during PDO distribution of the PDO message

--- a/tests/integration/tests/pdo_rx.c
+++ b/tests/integration/tests/pdo_rx.c
@@ -374,6 +374,105 @@ TS_DEF_MAIN(TS_RPdo_UpdateType255)
     CHK_NO_ERR(&node);
 }
 
+/*------------------------------------------------------------------------------------------------*/
+/*!
+*          This testcase will check the principle reception of:
+*          - PDO #0 (7 dummy bytes and byte in content)
+*/
+/*------------------------------------------------------------------------------------------------*/
+TS_DEF_MAIN(TS_RPdo_Dummy_8_16_32_Data_Byte)
+{
+    CO_NODE  node;
+    uint32_t rpdo_id     = 0x40000200;
+    uint32_t rpdo_map[4] = { CO_RPDO_MAP_DUMMY_I8,
+                             CO_RPDO_MAP_DUMMY_I16,
+                             CO_RPDO_MAP_DUMMY_I32,
+                             0x25001208 }; /* data byte */
+    uint8_t  rpdo_type   = 254;
+    uint8_t  rpdo_len    = 4;
+    uint8_t  data        = { 0x91 };
+
+    TS_CreateMandatoryDir();
+    TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
+    TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
+    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_OBJ_____RW), CO_TUNSIGNED8, (CO_DATA)(&data));
+    TS_CreateNodeAutoStart(&node);
+
+    TS_PDO_SEND(0x201, 0x51);  /* send payload: 0x51 .. 0x58 */
+
+    /* check signals to be changed */
+    TS_ASSERT(0x58 == data);
+
+    /* check error free stack execution         */
+    CHK_NO_ERR(&node);                                
+}
+
+/*------------------------------------------------------------------------------------------------*/
+/*!
+*          This testcase will check the principle reception of:
+*          - PDO #0 (data byte and 7 dummy bytes in content)
+*/
+/*------------------------------------------------------------------------------------------------*/
+TS_DEF_MAIN(TS_RPdo_Data_Byte_Dummy_8_16_32)
+{
+    CO_NODE  node;
+    uint32_t rpdo_id     = 0x40000200;
+    uint32_t rpdo_map[4] = { 0x25001208, /* data byte */
+                             CO_RPDO_MAP_DUMMY_U8,
+                             CO_RPDO_MAP_DUMMY_U16,
+                             CO_RPDO_MAP_DUMMY_U32 };
+    uint8_t  rpdo_type   = 254;
+    uint8_t  rpdo_len    = 4;
+    uint8_t  data        = { 0x91 };
+
+    TS_CreateMandatoryDir();
+    TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
+    TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
+    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_OBJ_____RW), CO_TUNSIGNED8, (CO_DATA)(&data));
+    TS_CreateNodeAutoStart(&node);
+
+    TS_PDO_SEND(0x201, 0x51);  /* send payload: 0x51 .. 0x58 */
+
+    /* check signals to be changed */
+    TS_ASSERT(0x51 == data);
+
+    /* check error free stack execution         */
+    CHK_NO_ERR(&node);                                
+}
+
+/*------------------------------------------------------------------------------------------------*/
+/*!
+*          This testcase will check the principle reception of:
+*          - PDO #0 (3 dummy bytes, 2 data bytes, 3 dummy bytes in content)
+*/
+/*------------------------------------------------------------------------------------------------*/
+TS_DEF_MAIN(TS_RPdo_Dummy_24_Data_Word_Dummy_24)
+{
+    CO_NODE  node;
+    uint32_t rpdo_id     = 0x40000200;
+    uint32_t rpdo_map[3] = { CO_RPDO_MAP_DUMMY_I24,
+                             0x25001210,   /* data word */
+                             CO_RPDO_MAP_DUMMY_U24,
+                            };
+    uint8_t  rpdo_type   = 254;
+    uint8_t  rpdo_len    = 3;
+    uint16_t data        = { 0x9192 };
+
+    TS_CreateMandatoryDir();
+    TS_CreateRPdoCom(0, &rpdo_id,     &rpdo_type);
+    TS_CreateRPdoMap(0, &rpdo_map[0], &rpdo_len);
+    TS_ODAdd(CO_KEY(0x2500, 0x12, CO_OBJ_____RW), CO_TUNSIGNED16, (CO_DATA)(&data));
+    TS_CreateNodeAutoStart(&node);
+
+    TS_PDO_SEND(0x201, 0x51);  /* send payload: 0x51 .. 0x58 */
+
+    /* check signals to be changed */
+    TS_ASSERT(0x5554 == data);
+
+    /* check error free stack execution         */
+    CHK_NO_ERR(&node);                                
+}   
+
 /******************************************************************************
 * PUBLIC FUNCTIONS
 ******************************************************************************/
@@ -403,6 +502,10 @@ SUITE_PDO_RX()
     TS_RUNNER(TS_RPdo_UpdateAfterSync);
     TS_RUNNER(TS_RPdo_UpdateType254);
     TS_RUNNER(TS_RPdo_UpdateType255);
+
+    TS_RUNNER(TS_RPdo_Dummy_8_16_32_Data_Byte);
+    TS_RUNNER(TS_RPdo_Data_Byte_Dummy_8_16_32);
+    TS_RUNNER(TS_RPdo_Dummy_24_Data_Word_Dummy_24);
 
     TS_End();
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -23,6 +23,14 @@ target_include_directories(ut-test-env
     env
 )
 
+# disable the compiler warnings (on windows only) around security of
+# some C99 standard functions like fopen() or strncpy() in the unit tests
+#
+target_compile_definitions(ut-test-env
+  INTERFACE
+    _CRT_SECURE_NO_WARNINGS
+)
+
 #---
 # unit tests
 #

--- a/tests/unit/object/cia301/co_pdo_map/main.c
+++ b/tests/unit/object/cia301/co_pdo_map/main.c
@@ -116,14 +116,15 @@ void test_write_mapping(void)
     uint8_t  data8 = 0x22;
     uint32_t val   = CO_LINK(0x2345,67,8);
     CO_ERR   err;
-    CO_OBJ   Obj[3] = {
+    CO_OBJ   Obj[4] = {
         { CO_KEY(0x1800, 1, CO_OBJ_D___RW), CO_TPDO_ID, (CO_DATA)((1ul<<31)|200uL)}, /* inactive 200h */
+        { CO_KEY(0x1A00, 0, CO_OBJ_D___RW), CO_TUNSIGNED8, (CO_DATA)(0)}, /* number of entries */
         { CO_KEY(0x1A00, 1, CO_OBJ_____RW), CO_TPDO_MAP, (CO_DATA)(&data)},
         { CO_KEY(0x2345,67, CO_OBJ____PRW), CO_TUNSIGNED8, (CO_DATA)(&data8)}
     };
-    (void)CODictInit(&AppNode.Dict, &AppNode, &Obj[0], 3);
+    (void)CODictInit(&AppNode.Dict, &AppNode, &Obj[0], 4);
 
-    err = COObjWrValue(&Obj[1], &AppNode, &val, sizeof(val));
+    err = COObjWrValue(&Obj[2], &AppNode, &val, sizeof(val));
 
     TEST_CHECK(err == CO_ERR_NONE);
 }


### PR DESCRIPTION
First some context. I tried to make an example for sync communication in which a sync producer and a sync consumer node are involved. The documentation can be found here [README.md](https://github.com/sandrogort/canopen-linux/blob/main/src/apps/setpoint/README.md). Upon receiving a PDO, there is only a RPDO callback (COPdoSyncUpdate) for synchronous communication but none for assynchronous. This example is inspired by the Lely CANopen stack tutorial [tutorial](https://opensource.lely.com/canopen/docs/cpp-tutorial/).

What I want is a callback also when the RPDO is written asynchronously. For that purpose a callback called COPdoAsyncUpdate was introduced. If I did reinvent the wheel here please let me know.

From an API perspective I am not sure if this ideal. The Lely stack provides a OnRpdoWrite callback independent of sync or async method which might be sufficient for most use cases.