### PR TITLE
co_pdo_map: Add error checking in COTPdoMapWrite

### DIFF
--- a/src/object/cia301/co_pdo_map.c
+++ b/src/object/cia301/co_pdo_map.c
@@ -73,6 +73,7 @@ static CO_ERR COTPdoMapWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     uint16_t  pmapidx;
     uint16_t  pcomidx;
     uint8_t   mapn;
+    CO_ERR    err;
 
     CO_UNUSED(size);
     ASSERT_PTR_ERR(obj, CO_ERR_BAD_ARG);
@@ -84,13 +85,19 @@ static CO_ERR COTPdoMapWrite(struct CO_OBJ_T *obj, struct CO_NODE_T *node, void 
     map     = *(uint32_t*)buffer;
 
     /* check that PDO is inactive */
-    (void)CODictRdLong(cod, CO_DEV(pcomidx, 1), &id);
+    err = CODictRdLong(cod, CO_DEV(pcomidx, 1), &id);
+    if (err != CO_ERR_NONE) {
+        return err;
+    }
     if ((id & CO_TPDO_COBID_OFF) == 0) {
         return (CO_ERR_OBJ_ACC);
     }
 
     /* check number of PDO mapping entries */
-    (void)CODictRdByte(cod, CO_DEV(pmapidx, 0), &mapn);
+    err = CODictRdByte(cod, CO_DEV(pmapidx, 0), &mapn);
+    if (err != CO_ERR_NONE) {
+        return err;
+    }
     if (mapn != 0) {
         return (CO_ERR_OBJ_ACC);
     }

--- a/tests/unit/object/cia301/co_pdo_map/main.c
+++ b/tests/unit/object/cia301/co_pdo_map/main.c
@@ -116,14 +116,15 @@ void test_write_mapping(void)
     uint8_t  data8 = 0x22;
     uint32_t val   = CO_LINK(0x2345,67,8);
     CO_ERR   err;
-    CO_OBJ   Obj[3] = {
+    CO_OBJ   Obj[4] = {
         { CO_KEY(0x1800, 1, CO_OBJ_D___RW), CO_TPDO_ID, (CO_DATA)((1ul<<31)|200uL)}, /* inactive 200h */
+        { CO_KEY(0x1A00, 0, CO_OBJ_D___RW), CO_TUNSIGNED8, (CO_DATA)(0)}, /* number of entries */
         { CO_KEY(0x1A00, 1, CO_OBJ_____RW), CO_TPDO_MAP, (CO_DATA)(&data)},
         { CO_KEY(0x2345,67, CO_OBJ____PRW), CO_TUNSIGNED8, (CO_DATA)(&data8)}
     };
-    (void)CODictInit(&AppNode.Dict, &AppNode, &Obj[0], 3);
+    (void)CODictInit(&AppNode.Dict, &AppNode, &Obj[0], 4);
 
-    err = COObjWrValue(&Obj[1], &AppNode, &val, sizeof(val));
+    err = COObjWrValue(&Obj[2], &AppNode, &val, sizeof(val));
 
     TEST_CHECK(err == CO_ERR_NONE);
 }


### PR DESCRIPTION
- Fixes uninitialized value read on failed CODictRdLong in COTPdoMapWrite
- Fixes test flakyness in pdo_map/write_mapping unit test.
- Fixes #142 