### PR TITLE
Callback function for both synchronous and asynchronous RPDO write

### DIFF
--- a/src/config/callbacks.c
+++ b/src/config/callbacks.c
@@ -185,7 +185,7 @@ void COPdoUpdate(CO_RPDO *pdo)
 
     /* Optional: place here some code, which is called
      * right after the object dictionary update due to
-     * a asynchronous PDO.
+     * a synchronous or asynchronous PDO.
      */
 }
 

--- a/src/config/callbacks.c
+++ b/src/config/callbacks.c
@@ -179,6 +179,18 @@ int16_t COPdoReceive(CO_IF_FRM *frm)
 }
 
 WEAK
+void COPdoUpdate(CO_RPDO *pdo)
+{
+    (void)pdo;
+
+    /* Optional: place here some code, which is called
+     * right after the object dictionary update due to
+     * a asynchronous PDO.
+     */
+}
+
+/* This function is deprecated, use COPdoUpdate instead. */
+WEAK
 void COPdoSyncUpdate(CO_RPDO *pdo)
 {
     (void)pdo;
@@ -186,17 +198,6 @@ void COPdoSyncUpdate(CO_RPDO *pdo)
     /* Optional: place here some code, which is called
      * right after the object dictionary update due to
      * a synchronized PDO.
-     */
-}
-
-WEAK
-void COPdoAsyncUpdate(CO_RPDO *pdo)
-{
-    (void)pdo;
-
-    /* Optional: place here some code, which is called
-     * right after the object dictionary update due to
-     * a asynchronous PDO.
      */
 }
 

--- a/src/config/callbacks.c
+++ b/src/config/callbacks.c
@@ -190,6 +190,17 @@ void COPdoSyncUpdate(CO_RPDO *pdo)
 }
 
 WEAK
+void COPdoAsyncUpdate(CO_RPDO *pdo)
+{
+    (void)pdo;
+
+    /* Optional: place here some code, which is called
+     * right after the object dictionary update due to
+     * a asynchronous PDO.
+     */
+}
+
+WEAK
 int16_t COParaDefault(struct CO_PARA_T *pg)
 {
     (void)pg;

--- a/src/service/cia301/co_pdo.c
+++ b/src/service/cia301/co_pdo.c
@@ -531,6 +531,7 @@ void CORPdoRx(CO_RPDO *pdo, CO_IF_FRM *frm)
     if (err == 0) {
         if ((pdo->Flag & CO_RPDO_FLG_S_) == 0) {
             CORPdoWrite(pdo, frm);
+            COPdoAsyncUpdate(pdo);
         } else {
             COSyncRx(&pdo->Node->Sync, frm);
         }

--- a/src/service/cia301/co_pdo.c
+++ b/src/service/cia301/co_pdo.c
@@ -531,7 +531,7 @@ void CORPdoRx(CO_RPDO *pdo, CO_IF_FRM *frm)
     if (err == 0) {
         if ((pdo->Flag & CO_RPDO_FLG_S_) == 0) {
             CORPdoWrite(pdo, frm);
-            COPdoAsyncUpdate(pdo);
+            COPdoUpdate(pdo);
         } else {
             COSyncRx(&pdo->Node->Sync, frm);
         }

--- a/src/service/cia301/co_pdo.h
+++ b/src/service/cia301/co_pdo.h
@@ -547,15 +547,15 @@ extern void COPdoTransmit(CO_IF_FRM *frm);
 */
 extern int16_t COPdoReceive(CO_IF_FRM *frm);
 
-/*! \brief  ASYNC UPDATE
+/*! \brief  RPDO UPDATE
 *
-*    This function is called just after the asynchronous RPDO is written to
-*    the object dictionary.
+*    This function is called just after the RPDO is written to the object
+*    dictionary.
 *
 * \param pdo
 *    Pointer to received RPDO
 */
-extern void COPdoAsyncUpdate(CO_RPDO *pdo);
+extern void COPdoUpdate(CO_RPDO *pdo);
 
 /*! \brief  PDO WRITE DATA CALLBACK
 *

--- a/src/service/cia301/co_pdo.h
+++ b/src/service/cia301/co_pdo.h
@@ -547,6 +547,16 @@ extern void COPdoTransmit(CO_IF_FRM *frm);
 */
 extern int16_t COPdoReceive(CO_IF_FRM *frm);
 
+/*! \brief  ASYNC UPDATE
+*
+*    This function is called just after the asynchronous RPDO is written to
+*    the object dictionary.
+*
+* \param pdo
+*    Pointer to received RPDO
+*/
+extern void COPdoAsyncUpdate(CO_RPDO *pdo);
+
 /*! \brief  PDO WRITE DATA CALLBACK
 *
 *    This function is called during PDO distribution of the PDO message

--- a/src/service/cia301/co_sync.c
+++ b/src/service/cia301/co_sync.c
@@ -144,6 +144,7 @@ void COSyncHandler (CO_SYNC *sync)
     for (i = 0; i < CO_RPDO_N; i++) {
         if (sync->RPdo[i] != 0) {
             CORPdoWrite(sync->RPdo[i], &sync->RFrm[i]);
+            COPdoUpdate(sync->RPdo[i]);
             COPdoSyncUpdate(sync->RPdo[i]);
         }
     }

--- a/src/service/cia301/co_sync.h
+++ b/src/service/cia301/co_sync.h
@@ -169,8 +169,19 @@ void COSyncProdSend(void *parg);
 * CALLBACK FUNCTIONS
 ******************************************************************************/
 
+/*! \brief  RPDO UPDATE
+*
+*    This function is called just after the RPDO is written to the object
+*    dictionary.
+*
+* \param pdo
+*    Pointer to received RPDO
+*/
+extern void COPdoUpdate(CO_RPDO *pdo);
+
 /*! \brief  SYNC UPDATE
 *
+*    This function is deprecated, use COPdoUpdate instead.
 *    This function is called just after the synchronized RPDO is written to
 *    the object dictionary.
 *

--- a/tests/integration/app/app_hooks.c
+++ b/tests/integration/app/app_hooks.c
@@ -81,6 +81,9 @@ void TS_CallbackInit(TS_CALLBACK *cb)
     cb->LssLoad_Called = 0;
     cb->LssLoad_Return = CO_ERR_NONE;
 
+    cb->PdoUpdate_ArgPdo = 0;
+    cb->PdoUpdate_Called = 0;    
+
     cb->PdoSyncUpdate_ArgPdo = 0;
     cb->PdoSyncUpdate_Called = 0;
 
@@ -250,6 +253,14 @@ int16_t COParaDefault(CO_PARA *pg)
     }
 
     return (result);
+}
+
+void COPdoUpdate(CO_RPDO *pdo)
+{
+    if (TsCallbacks != 0) {
+        TsCallbacks->PdoUpdate_ArgPdo = pdo;
+        TsCallbacks->PdoUpdate_Called++;
+    }
 }
 
 void COPdoSyncUpdate(CO_RPDO *pdo)

--- a/tests/integration/app/app_hooks.h
+++ b/tests/integration/app/app_hooks.h
@@ -103,6 +103,9 @@ typedef struct TS_CALLBACK_T {
     uint32_t    ParaDefault_Called;
     int16_t     ParaDefault_Return;
 
+    CO_RPDO    *PdoUpdate_ArgPdo;
+    uint32_t    PdoUpdate_Called;    
+
     CO_RPDO    *PdoSyncUpdate_ArgPdo;
     uint32_t    PdoSyncUpdate_Called;
 


### PR DESCRIPTION
Follow-up pull request for [Callback function for RPDO which are not synchronous #141](https://github.com/embedded-office/canopen-stack/pull/141). Instead of adding COPdoAsyncUpdate callback, it was decided to have only a common COPdoUpdate callback for both synchronous and asynchronous RPDO write. COPdoSyncUpdate is for the moment deprecated but not removed in order to have no breaking changes. It might get removed in a future release.