### PR TITLE
Support fastscan on LSS slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The source code is compliant to the C99 standard and you must cross-compile the 
 
 - Baudrate configuration
 - NodeId configuration
+- Fastscan slave service
 
 *Note: the term 'unlimited' means, that the implementation introduces no additional limit. There are technical limits, described in the specification (for example: up to 511 possible TPDOs)*
 

--- a/src/service/cia305/co_lss.c
+++ b/src/service/cia305/co_lss.c
@@ -46,7 +46,8 @@ static const CO_LSS_MAP COLssServices[CO_LSS_MAX_SID] = {
     {  73 , CO_LSS_WAIT | CO_LSS_CONF, COLssIdentifyRemoteSlave_RevMax },
     {  74 , CO_LSS_WAIT | CO_LSS_CONF, COLssIdentifyRemoteSlave_SerMin },
     {  75 , CO_LSS_WAIT | CO_LSS_CONF, COLssIdentifyRemoteSlave_SerMax },
-    {  76 , CO_LSS_WAIT | CO_LSS_CONF, COLssNonConfiguredRemoteSlave }
+    {  76 , CO_LSS_WAIT | CO_LSS_CONF, COLssNonConfiguredRemoteSlave },
+    {  81 , CO_LSS_WAIT              , COLssFastscan }
 };
 
 static const uint32_t CO_LssBaudTbl[CO_LSS_MAX_BAUD] = {
@@ -505,5 +506,70 @@ int16_t COLssNonConfiguredRemoteSlave(CO_LSS *lss, CO_IF_FRM *frm)
         result = 1;
     }
     return result;
+}
+
+int16_t COLssFastscan(CO_LSS *lss, CO_IF_FRM *frm)
+{
+    CO_NODE *node = lss->Node;
+    uint32_t idNumber;
+    uint32_t idCompared;
+    uint32_t mask;
+    uint8_t bitCheck;
+    uint8_t lssSub;
+    uint8_t lssNext;
+    CO_ERR err;
+
+    /* Only for non-configured nodes */
+    if ((node->NodeId != (uint8_t)0xff) || ((lss->Flags & CO_LSS_STORED) == 0))
+    {
+        goto no_response;
+    }
+
+    idNumber = CO_GET_LONG(frm, 1);
+    bitCheck = CO_GET_BYTE(frm, 5);
+    lssSub = CO_GET_BYTE(frm, 6);
+    lssNext = CO_GET_BYTE(frm, 7);
+
+    /* Check for validity */
+    if (bitCheck > CO_LSS_FASTSCAN_MSB && bitCheck != CO_LSS_FASTSCAN_CONFIRM)
+        goto no_response; /* Bitcheck is invalid  */
+    if (lssSub > CO_LSS_FASTSCAN_SERIAL || lssNext > CO_LSS_FASTSCAN_SERIAL)
+        goto no_response; /* lssNext and lssSub are invalid */
+
+    /* Send confirmation */
+    if (bitCheck == CO_LSS_FASTSCAN_CONFIRM)
+        goto response;
+
+    if (lssSub == CO_LSS_FASTSCAN_VENDOR_ID)
+        err = CODictRdLong(&lss->Node->Dict, CO_DEV(0x1018, 1), &idCompared);
+    else if (lssSub == CO_LSS_FASTSCAN_PRODUCT)
+        err = CODictRdLong(&lss->Node->Dict, CO_DEV(0x1018, 2), &idCompared);
+    else if (lssSub == CO_LSS_FASTSCAN_REV)
+        err = CODictRdLong(&lss->Node->Dict, CO_DEV(0x1018, 3), &idCompared);
+    else
+        err = CODictRdLong(&lss->Node->Dict, CO_DEV(0x1018, 4), &idCompared);
+
+    if (err != CO_ERR_NONE)
+        goto no_response;
+
+    mask = 0xFFFFFFFF << bitCheck;
+    if ((idCompared & mask) == (idNumber & mask))
+    {
+        if (bitCheck == 0 && lssNext < lssSub)
+        {
+            /* Matched completely, we enter configuration state */
+            lss->Mode = CO_LSS_CONF;
+        }
+        goto response;
+    }
+
+no_response:
+    return -1;
+response:
+    CO_SET_LONG(frm, 0L, 0);
+    CO_SET_LONG(frm, 0L, 4);
+    CO_SET_BYTE(frm, CO_LSS_RES_SLAVE, 0);
+    CO_SET_ID(frm, CO_LSS_TX_ID);
+    return 1;
 }
 #endif //USE_LSS

--- a/src/service/cia305/co_lss.h
+++ b/src/service/cia305/co_lss.h
@@ -31,7 +31,7 @@ extern "C" {
 * PUBLIC DEFINES
 ******************************************************************************/
 
-#define CO_LSS_MAX_SID           21       /*!< number of LSS services        */
+#define CO_LSS_MAX_SID           22       /*!< number of LSS services        */
 #define CO_LSS_MAX_BAUD          10       /*!< number of standard baudrates  */
 
 #define CO_LSS_RX_ID           2021       /*!< LSS request identifier        */
@@ -62,6 +62,15 @@ extern "C" {
 #define CO_LSS_REM_REVISION_MAX  13
 #define CO_LSS_REM_SERIAL_MIN    14
 #define CO_LSS_REM_SERIAL_MAX    15
+
+#define CO_LSS_FASTSCAN_LSB      0
+#define CO_LSS_FASTSCAN_MSB      31
+#define CO_LSS_FASTSCAN_CONFIRM  128
+
+#define CO_LSS_FASTSCAN_VENDOR_ID 0
+#define CO_LSS_FASTSCAN_PRODUCT   1
+#define CO_LSS_FASTSCAN_REV       2
+#define CO_LSS_FASTSCAN_SERIAL    3
 
 /******************************************************************************
 * PUBLIC TYPES
@@ -139,6 +148,7 @@ int16_t COLssIdentifyRemoteSlave_RevMax(CO_LSS *lss, CO_IF_FRM *frm);
 int16_t COLssIdentifyRemoteSlave_SerMin(CO_LSS *lss, CO_IF_FRM *frm);
 int16_t COLssIdentifyRemoteSlave_SerMax(CO_LSS *lss, CO_IF_FRM *frm);
 int16_t COLssNonConfiguredRemoteSlave(CO_LSS *lss, CO_IF_FRM *frm);
+int16_t COLssFastscan(CO_LSS *lss, CO_IF_FRM *frm);
 
 /******************************************************************************
 * CALLBACK FUNCTIONS


### PR DESCRIPTION
I've integrated your canopen stack on a personnal project and needed to have automatic node addressing.
After reading the specification, I noticed your implementation lacked the fastscan feature on the slave side.

Your stack is the nicest I've worked with so far and I must thank you a lot for that.
Examples are really nice, it's very well designed and the module packaging is wonderful, that's the most painless experience I've ever had trying to add an external dependency with cmake, thanks a lot !

I'm fairly new to canopen and I'm still discovering, I've read the specification and implemented the fastscan feature so that other people can benefit from it :)

It's still curently under test on my side but it does seems to be working well so far.
I'm opening the PR early so I can have some feedback.

Notes:
* I used some gotos and I know it can be a turn off for a lot of people. I do think that's the most elegant way of using them and that it does make the logic very simple and nice to follow.
* I couldn't find how to build this stand alone, I hope I didn't make any mistake while copying and pasting from my own project
* I'm discovering canopen, I might have misunderstood a lot of things

Have a nice day :)