### PR TITLE
SDO Server: reset obj before read

### DIFF
--- a/src/service/cia301/co_ssdo.c
+++ b/src/service/cia301/co_ssdo.c
@@ -288,6 +288,7 @@ CO_ERR COSdoUploadExpedited(CO_SDO *srv)
     if (size == 0) {
         return (result);
     } else if (size <= 4) {
+        (void)COObjReset(srv->Obj, srv->Node, 0);
         err = COObjRdValue(srv->Obj, srv->Node, (void *)&data, (uint8_t)size);
         if (err != CO_ERR_NONE) {
             if (srv->Abort > 0) {


### PR DESCRIPTION
There is a subtle bug in SDO server: If you try to upload small string with length up to 4 bytes, the first upload is successful but next ones are wrong, because they start with wrong value of string's Offset. I'm fixing that by doing `COObjReset` before the read.
