### PR TITLE
Add platformio library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+  "build": {
+    "flags": [
+      "-Isrc/object/basic",
+      "-Isrc/core",
+      "-Isrc/object/cia301/",
+      "-Isrc/service/cia301/",
+      "-Isrc/service/cia305/",
+      "-Isrc/hal",
+      "-Isrc/config"
+    ],
+    "srcFilter": "+<*> -<driver/_template/>"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embedded-office/canopen-stack"
+  }
+}


### PR DESCRIPTION
This allows to use canopen-stack in platformio project, for example in ESPHome.

Example usage in esphome-canopen custom component: https://github.com/mrk-its/esphome-canopen/blob/main/components/canopen/__init__.py#L137

